### PR TITLE
Make nix-shell pure, update mozilla overlay

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,22 +1,17 @@
-with import
-  (fetchTarball {
+let
+  nixpkgs = fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31.tar.gz";
     # To update hash:
     #   nix-prefetch-url --type sha256 --unpack https://github.com/NixOS/nixpkgs/archive/....tar.gz
     sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
-  })
-{ };
-let
-  src = fetchFromGitHub {
-    owner = "mozilla";
-    repo = "nixpkgs-mozilla";
-    rev = "e912ed483e980dfb4666ae0ed17845c4220e5e7c";
-    sha256 = "08fvzb8w80bkkabc1iyhzd15f4sm7ra10jn32kfch5klgl0gj3j3";
   };
-  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  moz_overlay = import (fetchTarball {
+    url = "https://github.com/mozilla/nixpkgs-mozilla/archive/7c1e8b1dd6ed0043fb4ee0b12b815256b0b9de6f.tar.gz";
+    sha256 = "1a71nfw7d36vplf89fp65vgj3s66np1dc0hqnqgj5gbdnpm1bihl";
+  });
   NIGHTLY_DATE = "2021-08-01";
-  nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
-  rustNightly = (nixpkgs.rustChannelOf { date = "${NIGHTLY_DATE}"; channel = "nightly"; }).rust.override {
+  pkgs = import nixpkgs { overlays = [ moz_overlay ]; };
+  rustNightly = (pkgs.rustChannelOf { date = "${NIGHTLY_DATE}"; channel = "nightly"; }).rust.override {
     extensions = [
       "clippy-preview"
       "rustfmt-preview"
@@ -24,7 +19,7 @@ let
     ];
   };
 in
-with import "${src.out}/rust-overlay.nix" pkgs pkgs;
+with pkgs;
 stdenv.mkDerivation {
   name = "rust-env";
   buildInputs = [


### PR DESCRIPTION
- Update mozilla overlay.
- Remove imports of host nixpkgs (`<nixpkgs>`).
- Remove double import (?) of mozilla overlay.

The mozilla overlay that was previously pinned is from Feb 2020 and is not compatible with recent nixpkgs.

I think the mozilla overlay was used twice, once as overlay and once by importing `rust_overlay.nix`. I removed one of these steps `cargo test`still runs.

Tested this locally without network and couldn't make out a difference in time it took to activate it.