### PR TITLE
Bump rust version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       devShell =
         let
 
-          stableToolchain = pkgs.rust-bin.stable."1.58.1".minimal.override {
+          stableToolchain = pkgs.rust-bin.stable."1.59.0".minimal.override {
             extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
           };
           rustDeps = with pkgs; [

--- a/zerok/zerok_lib/src/full_persistence.rs
+++ b/zerok/zerok_lib/src/full_persistence.rs
@@ -115,6 +115,7 @@ impl FullPersistence {
             .iter()
             .flat_map(|txn| txn.output_commitments().into_iter())
         {
+            #[allow(clippy::init_numbered_fields)]
             self.rmt_leaves_full
                 .store_resource(&MerkleLeaf {
                     0: comm.to_field_element(),


### PR DESCRIPTION
Since 1.60.0 ICE-s on clippy (#223 ), bump to 1.59.0 which doesn't ICE. 