### PR TITLE
Use hyphens for CLI arguments and remove default names

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -24,7 +24,7 @@ The instructions below assume that the number of nodes is 7. Otherwise, replace 
     * Open 7 terminal windows (or split a window into 7 sessions using tmux). Let them be `window 0, 1, ..., 6`, each representing a node.
     * In each window:
         * Cd to `target/release/`.
-        * Run `./espresso-validator --config {config} --pk_path {pk_path} --id {id} --num_txn {num_txn}`.
+        * Run `./espresso-validator --config {config} --pk-path {pk_path} --id {id} --num-txn {num_txn}`.
             * `config` is the path to the node config file.
                 * Skip this option if using the default file, `validator/src/node-config.toml`.
             * `pk_path` is the directory where publik key files are stored.
@@ -40,7 +40,7 @@ The instructions below assume that the number of nodes is 7. Otherwise, replace 
 * To automate a single-command consensus:
     * In a terminal window:
         * Cd to `target/release/`.
-        * Run `./multi_machine_automation --num_txn {num_txn} --config {config} --pk_path {pk_path}`.
+        * Run `./multi_machine_automation --num-txn {num_txn} --config {config} --pk-path {pk_path}`.
             * `num_txn` is the number of transactions to generate.
                 * If skipped, the consensus will keep running till the process is killed. For easier manual testing, do not skip it.
             * `config` is the path to the node config file.

--- a/validator/src/bin/espresso-validator.rs
+++ b/validator/src/bin/espresso-validator.rs
@@ -27,11 +27,11 @@ struct Options {
     node_opt: NodeOpt,
 
     /// Path to the node configuration file.
-    #[structopt(long = "config", short = "c")]
+    #[structopt(long, short)]
     pub config: Option<PathBuf>,
 
     /// Path to the universal parameter file.
-    #[structopt(long = "universal_param_path", short = "u")]
+    #[structopt(long, short)]
     pub universal_param_path: Option<String>,
 
     /// Whether to generate and store public keys for all nodes.
@@ -39,7 +39,7 @@ struct Options {
     /// Public keys will be stored under the directory specified by `pk_path`.
     ///
     /// Skip this option if public key files already exist.
-    #[structopt(long = "gen_pk", short = "g")]
+    #[structopt(long, short)]
     #[structopt(conflicts_with("id"))]
     pub gen_pk: bool,
 
@@ -47,7 +47,7 @@ struct Options {
     ///
     /// Public keys will be stored under the specified directory, file names starting
     /// with `pk_`.
-    #[structopt(long = "pk_path", short = "p")]
+    #[structopt(long, short)]
     pub pk_path: Option<PathBuf>,
 
     /// Id of the current node.
@@ -55,8 +55,8 @@ struct Options {
     /// If the node ID is 0, it will propose and try to add transactions.
     ///
     /// Skip this option if only want to generate public key files.
-    #[structopt(long = "id", short = "i")]
-    #[structopt(conflicts_with("gen_pk"))]
+    #[structopt(long, short)]
+    #[structopt(conflicts_with("gen-pk"))]
     pub id: Option<u64>,
 
     /// Public key which should own a faucet record in the genesis block.
@@ -72,7 +72,7 @@ struct Options {
     /// Number of transactions to generate.
     ///
     /// If not provided, the validator will wait for externally submitted transactions.
-    #[structopt(long = "num_txn", short = "n", conflicts_with("faucet_pub_key"))]
+    #[structopt(long, short, conflicts_with("faucet-pub-key"))]
     pub num_txn: Option<u64>,
 
     /// Wait for web server to exit after transactions complete.

--- a/validator/src/bin/multi_machine_automation.rs
+++ b/validator/src/bin/multi_machine_automation.rs
@@ -16,18 +16,18 @@ struct Options {
     node_opt: NodeOpt,
 
     /// Path to the node configuration file.
-    #[structopt(long = "config", short = "c")]
+    #[structopt(long, short)]
     pub config: Option<PathBuf>,
 
     /// Path to the universal parameter file.
-    #[structopt(long = "universal_param_path", short = "u")]
+    #[structopt(long, short)]
     pub universal_param_path: Option<PathBuf>,
 
     /// Path to public keys.
     ///
     /// Public keys will be stored under the specified directory, file names starting
     /// with `pk_`.
-    #[structopt(long = "pk_path", short = "p")]
+    #[structopt(long, short)]
     pub pk_path: Option<PathBuf>,
 
     /// Public key which should own a faucet record in the genesis block.
@@ -43,7 +43,7 @@ struct Options {
     /// Number of transactions to generate.
     ///
     /// If not provided, the validator will wait for externally submitted transactions.
-    #[structopt(long = "num_txn", short = "n", conflicts_with("faucet_pub_key"))]
+    #[structopt(long, short, conflicts_with("faucet-pub-key"))]
     pub num_txn: Option<u64>,
 
     /// Wait for web server to exit after transactions complete.
@@ -60,7 +60,7 @@ async fn main() {
     let options = Options::from_args();
     let mut args = vec![];
     if options.node_opt.reset_store_state {
-        args.push("--reset_store_state");
+        args.push("--reset-store-state");
     }
     if options.node_opt.full {
         args.push("--full");
@@ -71,7 +71,7 @@ async fn main() {
     let store_path;
     if let Some(path) = &options.node_opt.store_path {
         store_path = path.display().to_string();
-        args.push("--store_path");
+        args.push("--store-path");
         args.push(&store_path);
     }
     let web_path;
@@ -95,13 +95,13 @@ async fn main() {
     let universal_param_path;
     if let Some(path) = &options.universal_param_path {
         universal_param_path = path.display().to_string();
-        args.push("--universal_param_path");
+        args.push("--universal-param-path");
         args.push(&universal_param_path);
     }
     let pk_path;
     if let Some(path) = &options.pk_path {
         pk_path = path.display().to_string();
-        args.push("--pk_path");
+        args.push("--pk-path");
         args.push(&pk_path);
     }
     let faucet_pub_keys = options
@@ -110,13 +110,13 @@ async fn main() {
         .map(|k| k.to_string())
         .collect::<Vec<_>>();
     for pub_key in &faucet_pub_keys {
-        args.push("--faucet_pub_key");
+        args.push("--faucet-pub-key");
         args.push(pub_key);
     }
     let num_txn;
     if let Some(num) = options.num_txn {
         num_txn = num.to_string();
-        args.push("--num_txn");
+        args.push("--num-txn");
         args.push(&num_txn);
     }
 

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -63,17 +63,17 @@ pub struct NodeOpt {
     ///
     /// If the path to a node's persistence files doesn't exist, its persisted state will be reset
     /// regardless of this argument.
-    #[structopt(long = "reset_store_state", short = "r")]
+    #[structopt(long, short)]
     pub reset_store_state: bool,
 
     /// Path to persistence files for all nodes.
     ///
     /// Persistence files will be nested under the specified directory.
-    #[structopt(long = "store_path", short = "s")]
+    #[structopt(long, short)]
     pub store_path: Option<PathBuf>,
 
     /// Whether the current node should run a full node.
-    #[structopt(long = "full", short = "f")]
+    #[structopt(long, short)]
     pub full: bool,
 
     /// Path to assets including web server files.
@@ -154,7 +154,7 @@ fn default_api_path() -> PathBuf {
 /// Gets the directory to persistence files.
 ///
 /// The returned path can be passed to `reset_store_dir` to remove the contents, if the
-/// `--reset_store_state` argument is true.
+/// `--reset-store-state` argument is true.
 fn get_store_dir(options: &NodeOpt, node_id: u64) -> PathBuf {
     options
         .store_path

--- a/zerok/zerok_client/src/cli_client.rs
+++ b/zerok/zerok_client/src/cli_client.rs
@@ -488,7 +488,7 @@ impl Validator {
                 .args([
                     "--config",
                     cfg_path.as_os_str().to_str().unwrap(),
-                    "--store_path",
+                    "--store-path",
                     store_path.as_os_str().to_str().unwrap(),
                     "--full",
                     "--id",


### PR DESCRIPTION
- Replaces underscores with hyphens for args.
- Removes unnecessarily specified long and short arg names.

Closes https://github.com/EspressoSystems/espresso/issues/253.