### PR TITLE
Restore automation test and update wait logic

### DIFF
--- a/validator/src/bin/espresso-validator.rs
+++ b/validator/src/bin/espresso-validator.rs
@@ -1,6 +1,7 @@
 // Copyright © 2021 Translucence Research, Inc. All rights reserved.
 #![deny(warnings)]
 
+use async_std::task::{sleep, spawn_blocking};
 use espresso_validator::*;
 use futures::{future::pending, StreamExt};
 use jf_cap::keys::UserPubKey;
@@ -8,6 +9,7 @@ use phaselock::{types::EventType, PubKey};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use structopt::StructOpt;
 use tagged_base64::TaggedBase64;
 use tracing::info;
@@ -180,7 +182,7 @@ async fn generate_transactions(
                 }
             } else {
                 info!("  - Proposing a transaction");
-                let (new_state, mut transactions) = async_std::task::spawn_blocking(move || {
+                let (new_state, mut transactions) = spawn_blocking(move || {
                     let txs = state
                         .generate_transactions(
                             vec![(true, 0, 0, 0, 0, -2)],
@@ -291,6 +293,9 @@ async fn generate_transactions(
         );
     }
     // !!!!!! END WARNING !!!!!!!
+
+    // Wait for other nodes to catch up.
+    sleep(Duration::from_secs(10)).await;
 }
 
 #[async_std::main]

--- a/validator/src/bin/multi_machine_automation.rs
+++ b/validator/src/bin/multi_machine_automation.rs
@@ -221,6 +221,7 @@ async fn main() {
         if expect_failure && (finished_nodes >= num_fail_nodes as usize) {
             break;
         }
+        // Pause before checking the exit status.
         sleep(Duration::from_secs(10)).await;
         for ((id, mut p), output) in core::mem::take(&mut processes)
             .into_iter()
@@ -323,12 +324,12 @@ mod test {
 
     #[async_std::test]
     async fn test_automation() {
-        automate(5, 0, 0, true).await;
         automate(5, 1, 3, true).await;
-        automate(5, 2, 2, true).await;
         automate(5, 3, 1, false).await;
 
-        // Disabling the following test case since it takes too long.
+        // Disabling the following test cases to avoid exceeding the time limit.
+        // automate(5, 0, 0, true).await;
+        // automate(5, 2, 2, true).await;
         // automate(50, 2, 10, true).await;
     }
 }


### PR DESCRIPTION
- With `phaselock v0.0.7`, the occasionally failed automation test now seems to pass, so removing `#[ignore]`.
- Replaces `wait` with `try_wait` for consensus processes to ensure `num_txn` succeeded transactions. 
- Closes https://github.com/EspressoSystems/espresso/issues/270.
- Closes https://github.com/EspressoSystems/espresso/issues/267.