### PR TITLE
feat: prune build artifacts

### DIFF
--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -35,12 +35,23 @@ jobs:
       - name: Quick Test Static Build
         timeout-minutes: 60
         run: |
-          nix run "github:NixOS/nix?ref=780c7731cd3e6fac05c1a13b244b5f7925f0010b" -- develop .#staticShell --option sandbox relaxed -c cargo run --release --bin multi_machine_automation -- --num-txn 3 --verbose
+          nix develop .#staticShell --option sandbox relaxed -c cargo run --release --bin multi_machine_automation -- --num-txn 3 --verbose
 
       - name: Compile all executables
         timeout-minutes: 60
         run: |
-          nix run "github:NixOS/nix?ref=780c7731cd3e6fac05c1a13b244b5f7925f0010b" -- develop .#staticShell --option sandbox relaxed -c cargo build --release
+          nix develop .#staticShell --option sandbox relaxed -c cargo build --release
+
+      # prune all untagged artifacts besides the most recent 5.
+      - uses: c-hive/gha-remove-artifacts@v1
+        if: ${{ github.event_name != 'pull_request' }}
+        name: Garbage collect old artifacts
+        with:
+          skip-tags: true
+          skip-recent: 5
+          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_PAT }}
+          age: '0 day'
+
 
       - name: Upload address book artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR:
- adds a GHA to prune untagged older artifacts such that any point in time only the 5 most recent commits to main have their artifacts uploaded