### PR TITLE
Allow contents of node-config.toml to be overridden by CLI/env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,6 +1815,8 @@ name = "espresso-validator"
 version = "0.1.0"
 dependencies = [
  "address-book",
+ "ark-serialize",
+ "ark-std",
  "async-std",
  "async-trait",
  "async-tungstenite 0.15.0",
@@ -5843,7 +5845,7 @@ dependencies = [
  "snafu",
  "structopt",
  "surf",
- "tagged-base64 0.1.0 (git+https://github.com/EspressoSystems/tagged-base64.git?branch=main)",
+ "tagged-base64 0.1.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.1.0)",
  "tempdir",
  "toml",
  "tracing",
@@ -5911,7 +5913,7 @@ dependencies = [
  "strum 0.20.0",
  "strum_macros",
  "surf",
- "tagged-base64 0.1.0 (git+https://github.com/EspressoSystems/tagged-base64.git?branch=main)",
+ "tagged-base64 0.1.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.1.0)",
  "tempdir",
  "threshold_crypto",
  "tide",

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ target/release/faucet
 | ESPRESSO_VALIDATOR_API_PATH | Path | espresso-validator | Path to validator API specification
 | ESPRESSO_VALIDATOR_PUB_KEY_PATH | Path | espresso-validator | Path to validator public keys
 | ESPRESSO_VALIDATOR_PORT    | u16  | espresso-validator   | Port on which to serve the query service and submit API
+| ESPRESSO_VALIDATOR_SECRET_KEY_SEED | TaggedBase64 (tag="SEED") | espresso-validator | Seed to use for generating threshold signature secret key (overrides the value from `node-config.toml`)
+| ESPRESSO_VALIDATOR_NODES | Vec<Url> | espresso-validator | Comma-separated list of URLs for validators in the network (overrides the value from `node-config.toml`)
 | ESPRESSO_ADDRESS_BOOK_STORE_PATH | Path | address-book   | Path to persistence files for address book service (default `$LOCAL/.espresso/espresso/address-book/store`)
 | ESPRESSO_ADDRESS_BOOK_PORT | u16  | address-book         | Port on which to serve the address book
 | ESPRESSO_ADDRESS_BOOK_URL  | Url  | zerok-client, faucet | URL of the address book service

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -8,6 +8,8 @@ default-run = "espresso-validator"
 
 [dependencies]
 address-book = { path = "../address-book" }
+ark-serialize = { version = "0.3.0", features = ["derive"] }
+ark-std = { version = "0.3.0", default-features = false }
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 async-trait = "0.1.51"
 async-tungstenite = { version = "0.15.0", features = ["async-std-runtime"] }

--- a/validator/src/testing.rs
+++ b/validator/src/testing.rs
@@ -1,6 +1,6 @@
 use crate::{
-    gen_pub_keys, init_validator, init_web_server, ConsensusConfig, GenesisState, Node, NodeConfig,
-    NodeOpt, MINIMUM_NODES,
+    gen_pub_keys, init_validator, init_web_server, ConsensusConfig, GenesisState, Node, NodeOpt,
+    MINIMUM_NODES,
 };
 use async_std::task::{block_on, spawn, JoinHandle};
 use futures::{channel::oneshot, future::join_all};
@@ -123,14 +123,19 @@ pub async fn minimal_test_network(rng: &mut ChaChaRng, faucet_pub_key: UserPubKe
     let mut seed = [0; 32];
     rng.fill_bytes(&mut seed);
     let nodes = iter::from_fn(|| {
-        Some(NodeConfig {
-            ip: "localhost".into(),
-            port: pick_unused_port().unwrap(),
-        })
+        let port = pick_unused_port().unwrap();
+        Some(
+            Url::parse(&format!("http://localhost:{}", port))
+                .unwrap()
+                .into(),
+        )
     })
     .take(MINIMUM_NODES)
     .collect();
-    let config = ConsensusConfig { seed, nodes };
+    let config = ConsensusConfig {
+        seed: seed.into(),
+        nodes,
+    };
 
     println!("generating public keys");
     let start = Instant::now();

--- a/zerok/zerok_client/Cargo.toml
+++ b/zerok/zerok_client/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.61"
 snafu = { version = "0.7", features = ["backtraces"] }
 structopt = { version = "0.3", features = ["paw"] }
 surf = "2.3.1"
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", branch = "main" }
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.1.0" }
 tempdir = "0.3.7"
 toml = "0.5"
 tracing = "0.1.26"

--- a/zerok/zerok_client/src/cli_client.rs
+++ b/zerok/zerok_client/src/cli_client.rs
@@ -2,7 +2,7 @@
 
 use async_std::task::{block_on, sleep, spawn_blocking};
 use escargot::CargoBuild;
-use espresso_validator::{testing::AddressBook, ConsensusConfig, NodeConfig};
+use espresso_validator::{testing::AddressBook, ConsensusConfig};
 use jf_cap::keys::UserPubKey;
 use portpicker::pick_unused_port;
 use regex::Regex;
@@ -243,12 +243,14 @@ impl CliClient {
             seed: [
                 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4,
                 5, 6, 7, 8,
-            ],
+            ]
+            .into(),
             nodes: phaselock_ports
                 .into_iter()
-                .map(|port| NodeConfig {
-                    ip: "localhost".into(),
-                    port: port as u16,
+                .map(|port| {
+                    Url::parse(&format!("http://localhost:{}", port))
+                        .unwrap()
+                        .into()
                 })
                 .collect(),
         };

--- a/zerok/zerok_lib/Cargo.toml
+++ b/zerok/zerok_lib/Cargo.toml
@@ -59,7 +59,7 @@ snafu = { version = "0.7", features = ["backtraces"] }
 strum = "0.20"
 strum_macros = "0.20.1"
 surf = "2.3.1"
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", branch = "main" }
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.1.0" }
 tempdir = "0.3.7"
 threshold_crypto = "0.4.0"
 tide = "0.16.0"


### PR DESCRIPTION
multi_machine_automation and espresso-validator now have the
following additional command line options/environment variables:
* --secret-key-seed, ESPRESSO_VALIDATOR_SECRET_KEY_SEED
  Override the `seed` field of node-config.toml
  Since the seed's type of [u8; 32] can't be conveniently written
  down in a command line or environment variable, it is passed as
  a TaggedBase64 with the tag SEED.
* --nodes, ESPRESSO_VALIDATOR_NODES
  Override the `nodes` array of node-config.toml. The nodes are
  given as a comma-separated list of URLs, which are parsed to figure
  out the host and port. When using the command line, `--nodes` can
  also be passed multiple times with one node each.

Closes #279