### PR TITLE
Un-hardcode x86_64-linux in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
             CARGO_BUILD_TARGET = "${arch}-unknown-${os}-musl";
             buildInputs = with pkgs;
               [ stableMuslRustToolchain fd cmake ];
+            meta.broken = if "${os}" == "darwin" then true else false;
           };
         };
 


### PR DESCRIPTION
`x86_64-linux` is pretty hardcoded into the staticShell right now. This removes the hardcoded values.