### PR TITLE
Turn off Tide default middleware logging

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -46,7 +46,7 @@ surf = "2.3.1"
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.0" }
 tempdir = "0.3.7"
 threshold_crypto = "0.4.0"
-tide = "0.16.0"
+tide = { version = "0.16.0", default-features = false }
 tide-websockets = "0.4.0"
 toml = "0.5"
 tracing = "0.1.26"


### PR DESCRIPTION
In the default configuration Tide has middleware that generates INFO level logging. With this disabled, we can use the RUST_LOG environment variable to select the appropriate level of logging.

This allows us to significantly reduce (or increase) the Validator logging output, however, it does not give us complete control because some libraries use `println!` to generate output unconditionally.