### PR TITLE
Remove the compact() directive so logs are easier to parse.

### DIFF
--- a/address-book/src/main.rs
+++ b/address-book/src/main.rs
@@ -12,7 +12,6 @@ async fn main() -> Result<(), std::io::Error> {
     let cleanup_signals = register_interrupt_signals();
 
     tracing_subscriber::fmt()
-        .compact()
         .with_ansi(false)
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -247,7 +247,6 @@ pub async fn init_web_server(
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tracing_subscriber::fmt()
-        .compact()
         .with_ansi(false)
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();

--- a/validator/src/bin/espresso-validator.rs
+++ b/validator/src/bin/espresso-validator.rs
@@ -315,7 +315,6 @@ async fn generate_transactions(
 async fn main() -> Result<(), std::io::Error> {
     let options = Options::from_args();
     tracing_subscriber::fmt()
-        .compact()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_ansi(options.colored_logs)
         .init();

--- a/validator/src/bin/test_query_api.rs
+++ b/validator/src/bin/test_query_api.rs
@@ -208,7 +208,6 @@ impl KeystoreLoader<EspressoLedger> for UnencryptedKeystoreLoader {
 #[async_std::main]
 async fn main() {
     tracing_subscriber::fmt()
-        .compact()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 

--- a/zerok/zerok_client/src/bin/random_wallet.rs
+++ b/zerok/zerok_client/src/bin/random_wallet.rs
@@ -179,7 +179,6 @@ async fn main() {
     let args = Args::from_args();
 
     tracing_subscriber::fmt()
-        .compact()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env().add_directive(Level::INFO.into()),
         )


### PR DESCRIPTION
Remove the compact() directive so logs are easier to parse.

https://espresso.zulipchat.com/#narrow/stream/317905-Fixed-Stake-Testnet-V1/topic/Logging/near/287082938