### PR TITLE
Use tracing instead of println!

### DIFF
--- a/zerok/zerok_client/src/bin/random_wallet.rs
+++ b/zerok/zerok_client/src/bin/random_wallet.rs
@@ -179,9 +179,7 @@ async fn main() {
     let args = Args::from_args();
 
     tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env().add_directive(Level::INFO.into()),
-        )
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_ansi(args.colored_logs)
         .init();
     event!(Level::INFO, "args = {:?}", args);


### PR DESCRIPTION
I still haven't figured out the difference in the the date format but this fixes 2 quick things.  First remove the println! and second to not force `Level::INFO`.