### PR TITLE
Clean up some TODO comments.

### DIFF
--- a/validator/src/bin/espresso-validator.rs
+++ b/validator/src/bin/espresso-validator.rs
@@ -1,4 +1,15 @@
-// Copyright © 2021 Translucence Research, Inc. All rights reserved.
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Espresso library.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not,
+// see <https://www.gnu.org/licenses/>.
+
 #![deny(warnings)]
 
 use async_std::task::{sleep, spawn_blocking};
@@ -189,7 +200,6 @@ async fn generate_transactions(
             if let Some(tx) = txn.as_ref() {
                 info!("  - Reproposing a transaction");
                 if txn_proposed_round + 5 < round {
-                    // TODO
                     phaselock.submit_transaction(tx.clone().3).await.unwrap();
                     txn_proposed_round = round;
                 }

--- a/zerok/zerok_client/tests/demo2.rs
+++ b/zerok/zerok_client/tests/demo2.rs
@@ -116,6 +116,7 @@ fn demo2() {
             //  * show that all validators have the same state commitment (/getsnapshot)
             //  * show the public information about the committed block (/getblock, /gettransaction,
             //    /getunspentrecord)
+            // https://github.com/EspressoSystems/espresso/issues/413
             //
             // Close a validator (not 0, that's the server for the keystores) and show that we can
             // still complete transactions.
@@ -145,6 +146,7 @@ fn demo2() {
             // TODO Query the state commitments again, showing that
             //  1. All the validator's still agree on the state
             //  2. The restarted valiator has caught up and now agrees on the latest state
+            // https://github.com/EspressoSystems/espresso/issues/413
             //
             // To show that non-native assets work just as well, define, mint and transfer one.
             // Define a new asset and mint some for the receiver.

--- a/zerok/zerok_lib/src/keystore/network.rs
+++ b/zerok/zerok_lib/src/keystore/network.rs
@@ -255,6 +255,7 @@ impl<'a> KeystoreBackend<'a, EspressoLedger> for NetworkBackend<'a> {
         url.set_scheme("ws").unwrap();
 
         //todo !jeb.bearer handle connection failures.
+        //      https://github.com/EspressoSystems/seahorse/issues/117
         // This should only fail if the server is incorrect or down, so we should handle by retrying
         // or failing over to a different server.
         let all_events = connect_async(url)
@@ -270,6 +271,7 @@ impl<'a> KeystoreBackend<'a, EspressoLedger> for NetworkBackend<'a> {
         Box::pin(
             chosen_events
                 //todo !jeb.bearer handle stream errors
+                //      https://github.com/EspressoSystems/seahorse/issues/117
                 // If there is an error in the stream, or the server sends us invalid data, we
                 // should retry or fail over to a different server.
                 .filter_map(|msg| {
@@ -341,7 +343,6 @@ impl<'a> KeystoreBackend<'a, EspressoLedger> for NetworkBackend<'a> {
     async fn submit(
         &mut self,
         txn: ElaboratedTransaction,
-        // TODO: do something with this?
         _txn_info: TransactionInfo<EspressoLedger>,
     ) -> Result<(), KeystoreError<EspressoLedger>> {
         Self::post(&self.validator_client, "/submit", &txn).await
@@ -366,7 +367,9 @@ impl<'a> KeystoreBackend<'a, EspressoLedger> for NetworkBackend<'a> {
             };
             let txid = TransactionId(BlockId(txid.0 as usize), txid.1 as usize);
             // TODO: fix the trait so we don't need this unwrap
+            //       https://github.com/EspressoSystems/seahorse/issues/223
             // TODO: include memos in transactions so we don't have to do this
+            //       https://github.com/EspressoSystems/espresso/issues/345
             Self::post(&self.query_client, format!("/memos/{}", txid), &body)
                 .await
                 .unwrap()
@@ -377,7 +380,6 @@ impl<'a> KeystoreBackend<'a, EspressoLedger> for NetworkBackend<'a> {
         &self,
         _from: EventIndex,
     ) -> Result<(MerkleTree, EventIndex), KeystoreError<EspressoLedger>> {
-        // TODO: how should this initialize?
         let LedgerSnapshot { records, .. } = self.get("getsnapshot/0/true").await?;
         Ok((records.0, Default::default()))
     }

--- a/zerok/zerok_lib/src/keystore/testing/mocks.rs
+++ b/zerok/zerok_lib/src/keystore/testing/mocks.rs
@@ -317,7 +317,6 @@ impl<'a> testing::SystemUnderTest<'a> for EspressoTest {
             events: MockEventSource::new(EventSource::QueryService),
         };
 
-        // TODO: should we make this deterministic?
         let mut rng = crate::testing::crypto_rng_from_seed([0x42u8; 32]);
 
         // Broadcast receiver memos for the records which are included in the tree from the start,

--- a/zerok/zerok_lib/src/ledger.rs
+++ b/zerok/zerok_lib/src/ledger.rs
@@ -51,6 +51,7 @@ impl traits::NullifierSet for SetMerkleTree {
             // generate a proof that the nullifier for one of our owned records is _not_ in the
             // tree. We should be more careful about pruning to cut down on the amount we have to
             // ask the network.
+            // https://github.com/EspressoSystems/espresso/issues/414
             self.forget(*nullifier);
         }
 

--- a/zerok/zerok_lib/src/node.rs
+++ b/zerok/zerok_lib/src/node.rs
@@ -647,7 +647,6 @@ impl FullState {
         }
 
         // Store and broadcast the new memos.
-        //todo !jeb.bearer update memos in storage
         let event = LedgerEvent::Memos {
             outputs: izip!(
                 new_memos,
@@ -678,8 +677,6 @@ impl<'a> PhaseLockQueryService<'a> {
         event_source: EventStream<impl ConsensusEvent + Send + std::fmt::Debug + 'static>,
 
         // The current state of the network.
-        //todo !jeb.bearer Query these parameters from another full node if we are not starting off
-        // a fresh network.
         univ_param: &'a jf_cap::proof::UniversalParam,
         mut validator: ValidatorState,
         record_merkle_tree: MerkleTree,
@@ -690,6 +687,8 @@ impl<'a> PhaseLockQueryService<'a> {
         //todo !jeb.bearer If we are not starting from the genesis of the ledger, query the full
         // state at this point from another full node, like
         //  let state = other_node.full_state(validator.commit());
+        // https://github.com/EspressoSystems/espresso/issues/415
+        //
         // For now, just assume we are starting at the beginning:
         let block_hashes = HashMap::new();
         // Use the unpruned record Merkle tree.
@@ -865,8 +864,6 @@ impl<'a, NET: PLNet, STORE: PLStore> FullNode<'a, NET, STORE> {
         validator: LightWeightNode<NET, STORE>,
 
         // The current state of the network.
-        //todo !jeb.bearer Query these parameters from another full node if we are not starting off
-        // a fresh network.
         univ_param: &'a jf_cap::proof::UniversalParam,
         state: ValidatorState,
         record_merkle_tree: MerkleTree,
@@ -1250,6 +1247,7 @@ mod tests {
 
                     // Posting the same memos twice should fail.
                     // todo !jeb.bearer re-enable this test when persistent memo storage is supported
+                    //      https://github.com/EspressoSystems/espresso/issues/345
                     // match qs
                     //     .post_memos(block_id as u64, txn_id as u64, memos.clone(), sig.clone())
                     //     .await
@@ -1262,6 +1260,7 @@ mod tests {
 
                     // We should be able to query the newly posted memos.
                     // todo !jeb.bearer re-enable this test when persistent memo storage is supported
+                    //      https://github.com/EspressoSystems/espresso/issues/345
                     // let (queried_memos, sig) =
                     //     qs.get_memos(block_id as u64, txn_id as u64).await.unwrap();
                     // txn.verify_receiver_memos_signature(&queried_memos, &sig)


### PR DESCRIPTION
For a number of vague or unlinked TODOs, either remove them if they
are obsolete, or clarify them and make sure they are all linked to
GitHub issues.