### PR TITLE
Optimize binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 resolver = "2"
 
 members = [
-	"address-book",
+    "address-book",
     "faucet",
     "validator",
     "zerok/apis/availability",
@@ -23,9 +23,9 @@ members = [
     "zerok/apis/status",
     "zerok/zerok_client",
     "zerok/zerok_lib",
-    ]
+  ]
 [profile.dev]
 opt-level = 1
 [profile.release]
 debug = true
-# lto = "thin"
+lto = "thin"


### PR DESCRIPTION
Why:
  Binary uploads are becoming a non-trivial part of build times
  Discussion on zulip landed on multiple options to greatly reduce size
  LTO=thin provides benefits with no notable downsides

How:
  enable LTO thin mode on release builds by default