### PR TITLE
Remove an ancient TODO of unknown origin

### DIFF
--- a/zerok/zerok_lib/src/testing.rs
+++ b/zerok/zerok_lib/src/testing.rs
@@ -1165,7 +1165,6 @@ pub fn crypto_rng_from_seed(seed: [u8; 32]) -> ChaChaRng {
     ChaChaRng::from_seed(seed)
 }
 
-// TODO(joe): proper Err returns
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This removes a TODO that was carried over from the prehistory of our
repository. If I had to guess, the original comment was supposed to be
on `MultiXfrTestState`, where `.unwrap()` was being used instead of `?`
and a `Result` return.