### PR TITLE
Fixes for multi_machine_automation

### DIFF
--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Quick Test Static Build
         timeout-minutes: 60
         run: |
-          nix develop .#staticShell --option sandbox relaxed -c cargo run --release --bin multi_machine_automation -- --num-txn 3 --verbose
+          nix develop .#staticShell --option sandbox relaxed -c cargo run --release --bin multi_machine_automation -- --num-txn 3 --verbose --reset-store-state
 
       - name: Compile all executables
         timeout-minutes: 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,6 +2196,7 @@ dependencies = [
  "async-trait",
  "async-tungstenite 0.15.0",
  "bincode",
+ "dirs",
  "escargot",
  "espresso-availability-api",
  "espresso-catchup-api",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -26,6 +26,7 @@ async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 async-trait = "0.1.56"
 async-tungstenite = { version = "0.15.0", features = ["async-std-runtime"] }
 bincode = "1.3.3"
+dirs = "4.0"
 escargot = "0.5.2"
 espresso-availability-api = { path = "../zerok/apis/availability" }
 espresso-catchup-api = { path = "../zerok/apis/catchup" }

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -21,6 +21,7 @@ use ark_serialize::*;
 use async_std::sync::{Arc, RwLock};
 use async_std::task;
 use async_trait::async_trait;
+use dirs::data_local_dir;
 use hotshot::{
     traits::implementations::{AtomicStorage, WNetwork},
     types::{Message, SignatureKey},
@@ -37,6 +38,7 @@ use rand_chacha::{rand_core::SeedableRng as _, ChaChaRng};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use server::request_body;
 use std::collections::hash_map::HashMap;
+use std::env;
 use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
@@ -296,15 +298,12 @@ fn default_web_path() -> PathBuf {
 
 /// Returns the default directory to store persistence files.
 fn default_store_path(node_id: u64) -> PathBuf {
-    const STORE_DIR: &str = "store";
-    let dir = project_path();
-    [
-        &dir,
-        Path::new(STORE_DIR),
-        Path::new(&format!("node{}", node_id)),
-    ]
-    .iter()
-    .collect()
+    let mut data_dir = data_local_dir()
+        .unwrap_or_else(|| env::current_dir().unwrap_or_else(|_| PathBuf::from("./")));
+    data_dir.push("espresso");
+    data_dir.push("validator");
+    data_dir.push(format!("node{}", node_id));
+    data_dir
 }
 
 /// Returns the default path to the API file.


### PR DESCRIPTION
* Use data_local_dir() for default storage directory, not source tree
* Use --reset-store-state when testing in build_static workflow