### PR TITLE
Increase Nix build timeout more

### DIFF
--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   nix:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Configure Git
         run: |


### PR DESCRIPTION
I'm setting it to run on pull requests just for this PR, so I can see if this passes. If it does, I'll switch it back to only running on merge.