### PR TITLE
Relegate faucet test to slow-tests.

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -1179,6 +1179,7 @@ mod test {
         faucet.stop().await;
     }
 
+    #[cfg(feature = "slow-tests")]
     #[async_std::test]
     #[traced_test]
     async fn test_faucet_transfer() {


### PR DESCRIPTION
It takes a very long and unpredictable amount of time due to escargot,
which is causing the Build workflow to have problems.