### PR TITLE
Increase timeout for faucet tests.

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -936,7 +936,7 @@ mod test {
 
     async fn retry<Fut: Future<Output = bool>>(f: impl Fn() -> Fut) {
         let mut backoff = Duration::from_millis(100);
-        for _ in 0..10 {
+        for _ in 0..13 {
             if f().await {
                 return;
             }


### PR DESCRIPTION
Due to a bug, the slow faucet tests were not running until recently.
Now that they are running, they are sometimes timing out, even
though the tests appear to work just fine when given enough time.
Hopefully increasing this timeout a little will make the Slow Tests
CI workflow a bit more resilient.