### PR TITLE
Disable libp2p logging in Nix shells and non-Nix CI workflows.

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Environment for local demo network.
 # This file is meant to work with docker-compose.yaml
 
-RUST_LOG=info
+RUST_LOG=info,libp2p=off
 
 ESPRESSO_VALIDATOR_NODES=http://validator0:40000,http://validator1:40001,http://validator2:40002,http://validator3:40003,http://validator4:40004,http://validator5:40005,http://validator6:40006
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
+env:
+  RUST_LOG: info,libp2p=off
+
 jobs:
   build:
     runs-on: [self-hosted, X64]

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   RUST_TEST_THREADS: 4
+  RUST_LOG: info,libp2p=off
 
 jobs:
   slow-tests:

--- a/flake.nix
+++ b/flake.nix
@@ -193,13 +193,15 @@
 
           RUST_SRC_PATH = "${nightlyToolchain}/lib/rustlib/src/rust/library";
           RUST_BACKTRACE = 1;
-          RUST_LOG = "info";
+          RUST_LOG = "info,libp2p=off";
         };
         devShells = {
           perfShell = pkgs.mkShell {
             shellHook = shellHook;
             buildInputs = with pkgs;
               [ cargo-llvm-cov nightlyToolchain ] ++ rustDeps;
+
+            RUST_LOG = "info,libp2p=off";
           };
 
           staticShell = pkgs.mkShell {
@@ -217,6 +219,8 @@
             buildInputs = with pkgs;
               [ nightlyMuslRustToolchain fd cmake ];
             meta.broken = if "${os}" == "darwin" then true else false;
+
+            RUST_LOG = "info,libp2p=off";
           };
         };
 


### PR DESCRIPTION
This is related to #490. It should make CI more stable and
improve the development experience. We still need to root cause the
issue with tracing, though.