### PR TITLE
Increase fd limit for slow tests and static build

### DIFF
--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Quick Test Static Build
         timeout-minutes: 60
         run: |
+          ulimit -n 4096
           nix develop .#staticShell --option sandbox relaxed -c cargo run --release --bin multi_machine_automation -- --num-txn 3 --verbose --reset-store-state
 
       - name: Compile all executables

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -40,4 +40,6 @@ jobs:
         name: Enable Rust Caching
 
       - name: Run Tests
-        run: cargo test --release --features=slow-tests
+        run: |
+          ulimit -n 4096
+          cargo test --release --features=slow-tests


### PR DESCRIPTION
This is an experiment to see if recent CI failures are due to the
test process running out of fds. If this is the case, this is not
a (good) solution, we should continue to investigate why the test
is using so many fds.