### PR TITLE
Fix determinism for `NullifierHistory::append_log`

### DIFF
--- a/core/src/testing.rs
+++ b/core/src/testing.rs
@@ -1181,7 +1181,6 @@ mod tests {
     use quickcheck::QuickCheck;
     use rand::{Rng, RngCore};
     use std::cmp::min;
-    use std::collections::HashMap;
 
     #[test]
     fn multixfr_setup() {
@@ -1904,8 +1903,7 @@ mod tests {
         // Our sliding window of recent nullifiers.
         let mut history = NullifierHistory::default();
         for (age, ages) in blocks {
-            let mut nullifier_proofs: HashMap<set_hash::Hash, Vec<(Nullifier, SetMerkleProof)>> =
-                HashMap::new();
+            let mut nullifier_proofs = NullifierProofs::default();
             for proof_age in once(age).chain(ages) {
                 // Use a proof that might be old, but is no older than the sliding window size or
                 // the size of all of history.
@@ -1917,23 +1915,18 @@ mod tests {
                 let set = &nullifier_sets[nullifier_sets.len() - 1 - proof_age];
                 let (contains, proof) = set.contains(n).unwrap();
                 assert!(!contains);
-                nullifier_proofs
-                    .entry(set.hash())
-                    .or_default()
-                    .push((n, proof));
+                nullifier_proofs.push((n, proof, set.hash()));
             }
 
             // Check the proofs.
             let recent_nullifiers = history.recent_nullifiers();
-            for (root, nulls) in &nullifier_proofs {
-                for (n, proof) in nulls {
-                    assert_eq!(
-                        *root,
-                        history
-                            .check_unspent(&recent_nullifiers, proof, *n)
-                            .unwrap()
-                    );
-                }
+            for (n, proof, root) in &nullifier_proofs {
+                assert_eq!(
+                    *root,
+                    history
+                        .check_unspent(&recent_nullifiers, proof, *n)
+                        .unwrap()
+                );
             }
 
             if nullifier_sets.len() > ValidatorState::HISTORY_SIZE + 1 {
@@ -1963,14 +1956,14 @@ mod tests {
             assert_ne!(prev_commit, history.commit());
 
             // Check that it returned all the expected proofs.
-            for (n, _) in nullifier_proofs.values().flatten() {
+            for (n, _, _) in &nullifier_proofs {
                 let (contains, _proof) = collected_proofs.contains(*n).unwrap();
                 assert!(!contains);
             }
 
             // Generate the new nullifiers set by inserting all of the new nullifiers.
             let mut set = nullifier_sets.last().unwrap().clone();
-            for (n, proof) in nullifier_proofs.into_values().flatten() {
+            for (n, proof, _) in nullifier_proofs.into_iter() {
                 set.insert(n).unwrap();
                 spent_nullifiers.push((n, proof));
             }
@@ -2004,5 +1997,74 @@ mod tests {
         QuickCheck::new()
             .tests(5)
             .quickcheck(test_nullifier_history as fn(u64, Vec<_>) -> ());
+    }
+
+    /// Test that applying equivalent blocks to the same [NullifierHistory] yields equal histories
+    /// with equal commitments. The blocks can have different nullifier proofs -- as long as the
+    /// nullifiers in both blocks are the same and all of the proofs are acceptable, they can be
+    /// relative to different historical root hashes, and the blocks are still equivalent.
+    ///
+    /// `blocks` is a sequence of non-empty lists of nullifier proof ages, similar to the format
+    /// accepted by `test_nullifier_history`, except that each proof has a pair of ages. This
+    /// defines two equivalent blocks which differ in the ages of their nullifier proofs. The test
+    /// applies each sequence of blocks to the same initial state, checking at each step that the
+    /// states and their commitments are equal.
+    fn test_nullifier_history_commitment(
+        seed: u64,
+        blocks: Vec<((usize, usize), Vec<(usize, usize)>)>,
+    ) {
+        let mut rng = ChaChaRng::seed_from_u64(seed);
+        // Past nullifier sets. Each of these Merkle trees is complete -- it contains leaves for
+        // each nullifier in the set.
+        let mut nullifier_sets = vec![SetMerkleTree::default()];
+        // Our sliding windows of recent nullifiers. These should always remain equal.
+        let mut history1 = NullifierHistory::default();
+        let mut history2 = NullifierHistory::default();
+        for (age, ages) in blocks {
+            let mut proofs1 = NullifierProofs::default();
+            let mut proofs2 = NullifierProofs::default();
+            for (age1, age2) in once(age).chain(ages) {
+                // Generate a random, fresh nullifier.
+                let n = Nullifier::random_for_test(&mut rng);
+                for (age, proofs) in [(age1, &mut proofs1), (age2, &mut proofs2)] {
+                    // Use a proof that might be old, but is no older than the sliding window size
+                    // or the size of all of history.
+                    let age = age % min(ValidatorState::HISTORY_SIZE + 1, nullifier_sets.len());
+                    // Find a recent nullifier set to generate the proof.
+                    let set = &nullifier_sets[nullifier_sets.len() - 1 - age];
+                    let (contains, proof) = set.contains(n).unwrap();
+                    assert!(!contains);
+                    proofs.push((n, proof, set.hash()));
+                }
+            }
+
+            // Insert the new nullifiers and make sure the effect on both histories is the same.
+            history1.append_block(proofs1.clone()).unwrap();
+            history2.append_block(proofs2).unwrap();
+            assert_eq!(history1, history2);
+            assert_eq!(history1.commit(), history2.commit());
+
+            // Generate the new nullifiers set by inserting all of the new nullifiers.
+            let mut set = nullifier_sets.last().unwrap().clone();
+            for (n, _, _) in proofs1.into_iter() {
+                set.insert(n).unwrap();
+            }
+            assert_eq!(set.hash(), history1.current_root());
+            assert_eq!(set.hash(), history2.current_root());
+            nullifier_sets.push(set);
+        }
+    }
+
+    #[test]
+    fn test_nullifier_history_commitment_regression() {
+        test_nullifier_history_commitment(0, vec![((0, 0), vec![]), ((0, 0), vec![(1, 0)])]);
+    }
+
+    #[cfg(feature = "slow-tests")]
+    #[test]
+    fn quickcheck_nullifier_history_commitment() {
+        QuickCheck::new()
+            .tests(5)
+            .quickcheck(test_nullifier_history_commitment as fn(u64, Vec<_>) -> ());
     }
 }


### PR DESCRIPTION
* Fix a bug where applying the same block with valid but differently-
  aged nullifier proofs would lead to different state commitments
* Replace bincode with canonical::serialize in `NullifierHistory::commit`,
  which is more, well, canonical for commitments
* Add a new property test to check that applying equivalent blocks with
  possibly different nullifier proofs leads to identical state commitments