### PR TITLE
Fixes for docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@
 RUST_LOG=info,libp2p=off
 
 ESPRESSO_VALIDATOR_BOOTSTRAP_HOSTS=http://validator0,http://validator1,http://validator2,http://validator3,http://validator4,http://validator5,http://validator6
+ESPRESSO_VALIDATOR_NUM_NODES=10
 
 # Use validator 0 as the canonical ESQS.
 ESPRESSO_VALIDATOR_CONSENSUS_PORT=40000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
   validator1:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 40001:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
       - 60001:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=1
@@ -50,7 +50,7 @@ services:
   validator2:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 40002:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
       - 60002:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=2
@@ -65,7 +65,7 @@ services:
   validator3:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 40003:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
       - 60003:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=3
@@ -80,7 +80,7 @@ services:
   validator4:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 40004:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
       - 60004:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=4
@@ -95,7 +95,7 @@ services:
   validator5:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 40005:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
       - 60005:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=5
@@ -110,7 +110,7 @@ services:
   validator6:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 40006:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
       - 60006:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=6
@@ -125,8 +125,8 @@ services:
   validator7:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
-      - 60006:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - 40007:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 60007:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=7
       - ESPRESSO_VALIDATOR_BOOTSTRAP_HOSTS
@@ -140,8 +140,8 @@ services:
   validator8:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
-      - 60006:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - 40008:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 60008:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=8
       - ESPRESSO_VALIDATOR_BOOTSTRAP_HOSTS
@@ -155,8 +155,8 @@ services:
   validator9:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
-      - 60006:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - 40009:$ESPRESSO_VALIDATOR_CONSENSUS_PORT/tcp
+      - 60009:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
     environment:
       - ESPRESSO_VALIDATOR_ID=9
       - ESPRESSO_VALIDATOR_BOOTSTRAP_HOSTS


### PR DESCRIPTION
* Set ESPRESSO_VALIDATOR_NUM_NODES in .env
* Use different host ports for each validator