### PR TITLE
Add memos to the elaborated txn before submission

### DIFF
--- a/validator_node/src/keystore/network.rs
+++ b/validator_node/src/keystore/network.rs
@@ -345,10 +345,8 @@ impl<'a> KeystoreBackend<'a, EspressoLedger> for NetworkBackend<'a> {
         mut txn: ElaboratedTransaction,
         txn_info: TransactionInfo<EspressoLedger>,
     ) -> Result<(), KeystoreError<EspressoLedger>> {
-        for opt_memo in txn_info.memos.into_iter() {
-            if let Some(memo) = opt_memo {
-                txn.memos.push(memo);
-            }
+        for memo in txn_info.memos.into_iter().flatten() {
+            txn.memos.push(memo);
         }
         txn.signature = txn_info.sig;
         


### PR DESCRIPTION
Left this little bit out from: https://github.com/EspressoSystems/espresso/pull/517

Since we aren't sending the memos via `post_memos` in `finalize` we need to add them to the transaction before we submit.  

We could make changes to reef and seahorse to have the memos automatically added to the cap transaction but I don't think it is clear that's what we want.