### PR TITLE
Increase view timeout from 10s to 100s.

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -562,7 +562,7 @@ async fn init_hotshot(
         threshold: NonZeroUsize::new(threshold as usize).unwrap(),
         max_transactions: NonZeroUsize::new(100).unwrap(),
         known_nodes,
-        next_view_timeout: 10_000,
+        next_view_timeout: 100_000,
         timeout_ratio: (11, 10),
         round_start_delay: 1,
         start_delay: 1,


### PR DESCRIPTION
This increases the length of the window in which a quorum of
validators must be in the same view to achieve progress, which
helps us work around bugs in view timeouts by increasing the
probability that any given view will succeed without a timeout.