### PR TITLE
Create a utility to measure system throughput over time.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cld"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce3655c23ebf9cdeed9a0cb47fd2f2f6b3333cb520fd6f8e852fae983ccbaae"
+
+[[package]]
 name = "clipboard-win"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,6 +2413,7 @@ dependencies = [
  "async-trait",
  "async-tungstenite 0.15.0",
  "bincode",
+ "cld",
  "dirs",
  "escargot",
  "espresso-availability-api",
@@ -2417,6 +2424,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hotshot",
+ "human_bytes",
  "itertools 0.10.3",
  "jf-cap",
  "jf-plonk",
@@ -3192,6 +3200,12 @@ name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
+name = "human_bytes"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a0d4dc39ec942e44c1c306aa196da67f2bd6a30dc7b4a475465c13ccf28817"
 
 [[package]]
 name = "ident_case"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -26,6 +26,7 @@ async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 async-trait = "0.1.56"
 async-tungstenite = { version = "0.15.0", features = ["async-std-runtime"] }
 bincode = "1.3.3"
+cld = "0.4"
 dirs = "4.0"
 escargot = "0.5.2"
 espresso-availability-api = { path = "../apis/availability" }
@@ -37,6 +38,7 @@ futures = "0.3.0"
 futures-util = "0.3.8"
 #hex = "0.4.3"
 hotshot = { git = "ssh://git@github.com/EspressoSystems/HotShot.git", tag = "0.1.3" }
+human_bytes = "0.3"
 itertools = "0.10.1"
 jf-cap = { features = ["std","test_apis"], git = "https://github.com/EspressoSystems/cap.git", branch = "testnet-v1" }
 jf-plonk = { features = ["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }

--- a/validator/src/bin/measure-throughput.rs
+++ b/validator/src/bin/measure-throughput.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Espresso library.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not,
+// see <https://www.gnu.org/licenses/>.
+
+use async_std::task::sleep;
+use cld::ClDuration;
+use human_bytes::human_bytes;
+use net::client::response_body;
+use std::fmt::{self, Display, Formatter};
+use std::ops::Sub;
+use std::time::{Duration, Instant};
+use structopt::StructOpt;
+use surf::Url;
+use tracing::{error, info};
+use validator_node::node::LedgerSummary;
+
+/// Measure system throughput over time by polling a query service.
+#[derive(StructOpt)]
+struct Options {
+    /// The frequency at which to poll current throughput.
+    #[structopt(short, long, default_value = "60s")]
+    frequency: ClDuration,
+
+    /// The total duration over which to measure throughput.
+    ///
+    /// If not provided, runs until killed.
+    #[structopt(short, long)]
+    total: Option<ClDuration>,
+
+    /// The query service to poll for ledger state.
+    #[structopt(short = "q", long, env = "ESPRESSO_ESQS_URL")]
+    esqs_url: Url,
+}
+
+#[derive(Clone, Debug)]
+struct Measurement {
+    duration: Duration,
+    transactions: usize,
+    bytes: usize,
+    blocks: usize,
+}
+
+impl Display for Measurement {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let s = self.duration.as_secs() as f32;
+        write!(
+            f,
+            "{:.2} tx/s, {}/s, {:.2} tx/block, {}/tx",
+            self.transactions as f32 / s,
+            human_bytes(self.bytes as f32 / s),
+            self.transactions as f32 / self.blocks as f32,
+            human_bytes(self.bytes as f32 / self.transactions as f32),
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Snapshot {
+    t: Instant,
+    state: LedgerSummary,
+}
+
+impl Snapshot {
+    async fn new(esqs_url: &Url) -> Result<Self, surf::Error> {
+        let mut res = surf::get(esqs_url.join("/getinfo").unwrap()).send().await?;
+        let state = response_body(&mut res).await?;
+        Ok(Self {
+            t: Instant::now(),
+            state,
+        })
+    }
+}
+
+impl Sub for &Snapshot {
+    type Output = Measurement;
+
+    fn sub(self, other: &Snapshot) -> Measurement {
+        Measurement {
+            duration: self.t - other.t,
+            transactions: self.state.num_txns - other.state.num_txns,
+            bytes: self.state.total_size - other.state.total_size,
+            blocks: self.state.num_blocks - other.state.num_blocks,
+        }
+    }
+}
+
+#[async_std::main]
+async fn main() -> surf::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let opt = Options::from_args();
+    let frequency = Duration::from(opt.frequency);
+    let total = opt.total.map(Duration::from);
+
+    let initial = Snapshot::new(&opt.esqs_url).await?;
+    let mut previous = initial.clone();
+
+    loop {
+        if let Some(total) = total {
+            if Instant::now() - initial.t > total {
+                break;
+            }
+        }
+
+        sleep(frequency).await;
+        match Snapshot::new(&opt.esqs_url).await {
+            Ok(new) => {
+                info!("Current {} | Total {}", &new - &previous, &new - &initial);
+                previous = new;
+            }
+            Err(err) => {
+                error!("Failed to fetch ledger state: {}", err);
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The program polls a query service at regular intervals, computing
current and total throughput (in terms of transactions and data)
and some other statistics, such as tx/block and bytes/tx.

This will help us take repeatable, comparable measurements of
throughput in a live system as we experiment with different scales
and configurations.

Example run:

```
% RUST_LOG=$RUST_LOG,surf=off  cargo run --release --bin measure-throughput -- -f 1m -t 10m -q http://localhost:60000
    Finished release [optimized + debuginfo] target(s) in 2.86s
     Running `target/release/measure-throughput -f 1m -t 10m -q 'http://localhost:60000'`
2022-08-02T05:02:44.140879Z  INFO measure_throughput: Current 0.20 tx/s, 670.1 B/s, 1.00 tx/block, 3.3 KB/tx | Total 0.20 tx/s, 670.1 B/s, 1.00 tx/block, 3.3 KB/tx
2022-08-02T05:03:44.149159Z  INFO measure_throughput: Current 0.18 tx/s, 518.8 B/s, 1.00 tx/block, 2.8 KB/tx | Total 0.19 tx/s, 594.5 B/s, 1.00 tx/block, 3 KB/tx
2022-08-02T05:04:44.157772Z  INFO measure_throughput: Current 0.18 tx/s, 521.8 B/s, 1.10 tx/block, 2.8 KB/tx | Total 0.19 tx/s, 570.2 B/s, 1.03 tx/block, 2.9 KB/tx
2022-08-02T05:05:44.163124Z  INFO measure_throughput: Current 0.13 tx/s, 349.8 B/s, 1.00 tx/block, 2.6 KB/tx | Total 0.17 tx/s, 515.1 B/s, 1.02 tx/block, 2.9 KB/tx
2022-08-02T05:06:44.173579Z  INFO measure_throughput: Current 0.13 tx/s, 438.6 B/s, 1.00 tx/block, 3.2 KB/tx | Total 0.17 tx/s, 499.8 B/s, 1.02 tx/block, 2.9 KB/tx
2022-08-02T05:07:44.183058Z  INFO measure_throughput: Current 0.12 tx/s, 336.9 B/s, 1.00 tx/block, 2.8 KB/tx | Total 0.16 tx/s, 472.7 B/s, 1.02 tx/block, 2.9 KB/tx
2022-08-02T05:08:44.191243Z  INFO measure_throughput: Current 0.10 tx/s, 317 B/s, 1.00 tx/block, 3.1 KB/tx | Total 0.15 tx/s, 450.4 B/s, 1.02 tx/block, 2.9 KB/tx
2022-08-02T05:09:44.656105Z  INFO measure_throughput: Current 0.12 tx/s, 375 B/s, 1.00 tx/block, 3.1 KB/tx | Total 0.15 tx/s, 441 B/s, 1.01 tx/block, 3 KB/tx
2022-08-02T05:10:44.740990Z  INFO measure_throughput: Current 0.10 tx/s, 302.5 B/s, 1.00 tx/block, 3 KB/tx | Total 0.14 tx/s, 425.6 B/s, 1.01 tx/block, 3 KB/tx
2022-08-02T05:11:45.442105Z  INFO measure_throughput: Current 0.13 tx/s, 382.7 B/s, 1.00 tx/block, 2.8 KB/tx | Total 0.14 tx/s, 420.6 B/s, 1.01 tx/block, 2.9 KB/t
```