### PR TITLE
Port Docker script and config to Ubuntu 20.04LTS

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,8 +20,8 @@ services:
   validator0:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40000:40000/tcp
-      - 60000:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40000:40000/tcp"
+      - "60000:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=0
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -43,8 +43,8 @@ services:
   validator1:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40001:40000/tcp
-      - 60001:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40001:40000/tcp"
+      - "60001:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=1
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -66,8 +66,8 @@ services:
   validator2:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40002:40000/tcp
-      - 60002:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40002:40000/tcp"
+      - "60002:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=2
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -89,8 +89,8 @@ services:
   validator3:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40003:40000/tcp
-      - 60003:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40003:40000/tcp"
+      - "60003:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=3
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -135,8 +135,8 @@ services:
   validator5:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40005:40000/tcp
-      - 60005:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40005:40000/tcp"
+      - "60005:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=5
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -158,8 +158,8 @@ services:
   validator6:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40006:40000/tcp
-      - 60006:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40006:40000/tcp"
+      - "60006:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=6
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -181,8 +181,8 @@ services:
   validator7:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40007:40000/tcp
-      - 60007:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40007:40000/tcp"
+      - "60007:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=7
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -205,8 +205,8 @@ services:
   validator8:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40008:40000/tcp
-      - 60008:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40008:40000/tcp"
+      - "60008:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=8
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR
@@ -229,8 +229,8 @@ services:
   validator9:
     image: ghcr.io/espressosystems/espresso/validator:main
     ports:
-      - 40009:40000/tcp
-      - 60009:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp
+      - "40009:40000/tcp"
+      - "60009:$ESPRESSO_VALIDATOR_QUERY_PORT/tcp"
     environment:
       - ESPRESSO_VALIDATOR_ID=9
       - ESPRESSO_VALIDATOR_REPLICATION_FACTOR

--- a/docker/build-images-sudo
+++ b/docker/build-images-sudo
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Espresso Systems (espressosys.com)
+# This file is part of the Espresso library.
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+# General Public License as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program. If not,
+# see <https://www.gnu.org/licenses/>.
+
+set -euo pipefail
+
+nix develop .#staticShell -c cargo build --release
+
+# Needed sudo to make this run on Ubuntu 20.04.4LTS and docker 20.10.14, build a224086349
+sudo docker build . -f docker/address-book.Dockerfile -t ghcr.io/espressosystems/espresso/address-book:main
+sudo docker build . -f docker/faucet.Dockerfile -t ghcr.io/espressosystems/espresso/faucet:main
+sudo docker build . -f docker/validator.Dockerfile -t ghcr.io/espressosystems/espresso/validator:main
+sudo docker build . -f docker/random-wallet.Dockerfile -t ghcr.io/espressosystems/espresso/random-wallet:main


### PR DESCRIPTION
Added quotes around ports and added sudo to make `docker/build-images-sudo && sudo docker up` work on Ubuntu 20.04LTS

Thanks to Jeb for figuring this out.