### PR TITLE
Remove Copy trait bound from KV tree hash keys and values

### DIFF
--- a/core/src/kv_merkle_tree.rs
+++ b/core/src/kv_merkle_tree.rs
@@ -75,10 +75,10 @@ where
 {
     /// Create a new leaf in the tree
     fn new_leaf(height: usize, key: KVHash::Key, value: KVHash::Value) -> Self {
-        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key));
+        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key.clone()));
         let key_bits = key_bit_vec.into_iter();
 
-        let mut h = KVHash::hash_leaf(key, value);
+        let mut h = KVHash::hash_leaf(key.clone(), value.clone());
 
         for sib in key_bits.into_iter().take(height) {
             let mut children = GenericArray::from_iter(vec![
@@ -207,13 +207,13 @@ where
         match self {
             EmptySubtree => KVHash::empty_digest(),
             Leaf { height, key, value } => {
-                let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(*key));
+                let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key.clone()));
 
                 // the path only goes until a terminal node is reached, so skip
                 // part of the bit-vec
                 let key_bits = key_bit_vec.into_iter();
 
-                let mut running_hash = KVHash::hash_leaf(*key, *value);
+                let mut running_hash = KVHash::hash_leaf(key.clone(), value.clone());
 
                 // if the height is too large, keep hashing
                 for sib in key_bits.chain(core::iter::repeat(0)).take(*height) {
@@ -259,7 +259,7 @@ where
     ) -> Option<(Option<KVHash::Value>, KVHash::Digest)> {
         let mut running_hash = self.terminal_node.value();
 
-        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key));
+        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key.clone()));
 
         // the path only goes until a terminal node is reached, so skip
         // part of the bit-vec
@@ -287,7 +287,7 @@ where
                     ..
                 } => {
                     if leaf_key == &key {
-                        Some((Some(*leaf_value), running_hash))
+                        Some((Some(leaf_value.clone()), running_hash))
                     } else {
                         Some((None, running_hash))
                     }
@@ -328,7 +328,7 @@ where
         key: KVHash::Key,
     ) -> Option<(Option<KVHash::Value>, KVMerkleProof<KVHash>)> {
         use KVMerkleTree::*;
-        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key));
+        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key.clone()));
         let key_bits = key_bit_vec.into_iter().rev();
 
         let mut path = Vec::new();
@@ -375,13 +375,13 @@ where
                 let proof = KVMerkleProof::<KVHash> {
                     terminal_node: KVMerkleTerminalNode::<KVHash>::Leaf {
                         height: *height,
-                        key: *leaf_key,
-                        value: *leaf_value,
+                        key: leaf_key.clone(),
+                        value: leaf_value.clone(),
                     },
                     path,
                 };
-                if key == *leaf_key {
-                    Some((Some(*leaf_value), proof))
+                if key == leaf_key.clone() {
+                    Some((Some(leaf_value.clone()), proof))
                 } else {
                     Some((None, proof))
                 }
@@ -394,7 +394,7 @@ where
     /// inserted, value1 is overwritten by value2.
     pub fn insert(&mut self, key: KVHash::Key, value: KVHash::Value) -> Option<()> {
         use KVMerkleTree::*;
-        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key));
+        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key.clone()));
         let mut end_height = key_bit_vec.len();
         let key_bits = key_bit_vec.into_iter().rev();
 
@@ -424,7 +424,8 @@ where
                     // Figure out if this leaf is down the same tree or if it's a sibling
                     let leaf_pos = {
                         debug_assert!(height > 0);
-                        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(leaf_key));
+                        let key_bit_vec =
+                            KVHash::traversal_of_digest(KVHash::hash_key(leaf_key.clone()));
                         key_bit_vec[height - 1]
                     };
 
@@ -491,7 +492,7 @@ where
 
     pub fn forget(&mut self, key: KVHash::Key) -> Option<KVMerkleProof<KVHash>> {
         use KVMerkleTree::*;
-        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key));
+        let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key.clone()));
         let key_bits = key_bit_vec.into_iter().rev();
 
         let mut siblings = vec![];
@@ -523,7 +524,7 @@ where
             key: leaf_key,
             value: leaf_value,
             ..
-        } = end_branch
+        } = end_branch.clone()
         {
             if leaf_key == key {
                 ret = Some(KVMerkleProof::<KVHash> {
@@ -592,7 +593,7 @@ where
         //check can be removed as an optimization opportunity if we really need
         //to, but keeping it in is defensive programming
 
-        let key_in_set = matches!(proof.check(key, self.hash()), Some((Some(_), ..)));
+        let key_in_set = matches!(proof.check(key.clone(), self.hash()), Some((Some(_), ..)));
 
         use KVMerkleTree::*;
         let key_bit_vec = KVHash::traversal_of_digest(KVHash::hash_key(key));
@@ -701,11 +702,11 @@ where
     let mut kvs = vec![];
     let mut s = KVMerkleTree::ForgottenSubtree { digest: root };
     for (k, v, proof) in inserts {
-        s.remember(k, proof)?;
+        s.remember(k.clone(), proof)?;
         kvs.push((k, v));
     }
     for (k, v) in kvs.iter() {
-        s.insert(*k, *v).unwrap();
+        s.insert(k.clone(), v.clone()).unwrap();
     }
     Ok((
         s.hash(),

--- a/core/src/tree_hash.rs
+++ b/core/src/tree_hash.rs
@@ -33,8 +33,8 @@ pub trait KVTreeHash: Copy + Clone + PartialEq + Eq + Debug {
         + CanonicalDeserialize;
     /// A data type for keys
     /// A data type for values
-    type Key: Debug + Copy + Clone + PartialEq + Eq + CanonicalSerialize + CanonicalDeserialize;
-    type Value: Debug + Copy + Clone + PartialEq + Eq + CanonicalSerialize + CanonicalDeserialize;
+    type Key: Debug + Clone + PartialEq + Eq + CanonicalSerialize + CanonicalDeserialize;
+    type Value: Debug + Clone + PartialEq + Eq + CanonicalSerialize + CanonicalDeserialize;
 
     /// The number of children each branch has minus one. This is due to the proof paths having sibling
     /// path lengths of n-1 and the generic implementation relying on type systems
@@ -205,7 +205,7 @@ pub mod treehash_tests {
         key: TH::Key,
         value: TH::Value,
     ) {
-        assert_ne!(TH::hash_leaf(key, value), TH::hash_key(key));
+        assert_ne!(TH::hash_leaf(key.clone(), value), TH::hash_key(key));
     }
 
     pub fn treehash_collision_sanity_checks1<TH: KVTreeHash>(
@@ -214,21 +214,33 @@ pub mod treehash_tests {
         k1: TH::Key,
         v1: TH::Value,
     ) {
-        if (k0, v0) == (k1, v1) {
-            assert_eq!(TH::hash_leaf(k0, v0), TH::hash_leaf(k1, v1));
+        if (k0.clone(), v0.clone()) == (k1.clone(), v1.clone()) {
+            assert_eq!(
+                TH::hash_leaf(k0.clone(), v0.clone()),
+                TH::hash_leaf(k1.clone(), v1.clone())
+            );
         } else {
-            assert_ne!(TH::hash_leaf(k0, v0), TH::hash_leaf(k1, v1));
+            assert_ne!(
+                TH::hash_leaf(k0.clone(), v0.clone()),
+                TH::hash_leaf(k1.clone(), v1.clone())
+            );
         }
 
         if k0 == k1 {
-            assert_eq!(TH::hash_key(k0), TH::hash_key(k1));
-            assert_eq!(TH::hash_leaf(k0, v0), TH::hash_leaf(k1, v0));
-            assert_eq!(TH::hash_leaf(k0, v1), TH::hash_leaf(k1, v1));
+            assert_eq!(TH::hash_key(k0.clone()), TH::hash_key(k1.clone()));
+            assert_eq!(
+                TH::hash_leaf(k0.clone(), v0.clone()),
+                TH::hash_leaf(k1.clone(), v0)
+            );
+            assert_eq!(TH::hash_leaf(k0, v1.clone()), TH::hash_leaf(k1, v1));
         } else {
-            assert_ne!(TH::hash_key(k0), TH::hash_key(k1));
+            assert_ne!(TH::hash_key(k0.clone()), TH::hash_key(k1.clone()));
 
-            assert_ne!(TH::hash_leaf(k0, v1), TH::hash_leaf(k1, v1));
-            assert_ne!(TH::hash_leaf(k0, v0), TH::hash_leaf(k1, v0));
+            assert_ne!(
+                TH::hash_leaf(k0.clone(), v1.clone()),
+                TH::hash_leaf(k1.clone(), v1)
+            );
+            assert_ne!(TH::hash_leaf(k0, v0.clone()), TH::hash_leaf(k1, v0));
         }
     }
 
@@ -243,7 +255,7 @@ pub mod treehash_tests {
         let mut all_results = HashSet::new();
         all_results.insert(TH::empty_digest());
 
-        assert!(all_results.insert(TH::hash_key(key)));
+        assert!(all_results.insert(TH::hash_key(key.clone())));
         assert!(all_results.insert(TH::hash_leaf(key, val)));
         assert!(all_results.insert(TH::hash_branch(&digests)));
 


### PR DESCRIPTION
Q: should I remove Copy for the digest as well?