### PR TITLE
Fix reset-store-state logic.

### DIFF
--- a/client/src/cli_client.rs
+++ b/client/src/cli_client.rs
@@ -540,7 +540,6 @@ impl Validator {
                     "12",
                     "--bootstrap-nodes",
                     &format!("localhost:{}", bootstrap_port),
-                    "--reset-store-state",
                 ])
                 .env("ESPRESSO_VALIDATOR_QUERY_PORT", server_port.to_string())
                 .env(

--- a/validator/src/testing.rs
+++ b/validator/src/testing.rs
@@ -11,8 +11,8 @@
 // see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    full_node_data_source::QueryData, gen_keys, init_validator, init_web_server, ConsensusOpt,
-    GenesisState, Node, NodeOpt, MINIMUM_NODES,
+    gen_keys, init_validator, init_web_server, open_data_source, ConsensusOpt, GenesisState, Node,
+    NodeOpt, MINIMUM_NODES,
 };
 use address_book::store::FileStore;
 use async_std::task::{block_on, spawn, JoinHandle};
@@ -188,21 +188,17 @@ pub async fn minimal_test_network(rng: &mut ChaChaRng, faucet_pub_key: UserPubKe
 
         store_path.push(i.to_string());
         async move {
-            let data_source = async_std::sync::Arc::new(async_std::sync::RwLock::new(
-                QueryData::new(&store_path).unwrap(),
-            ));
-
             let mut node_opt = NodeOpt {
                 store_path: Some(store_path),
                 nonbootstrap_base_port: base_port as usize,
                 next_view_timeout: Duration::from_secs(10 * 60),
-                reset_store_state: true,
                 ..NodeOpt::default()
             };
             if i == 0 {
                 node_opt.full = true;
                 node_opt.web_server_port = pick_unused_port().unwrap();
             }
+            let data_source = open_data_source(&mut node_opt, i);
             let node = init_validator(
                 &node_opt,
                 &consensus_opt,


### PR DESCRIPTION
The behavior involving `--reset-store-state` depends on whether
the storage directory exists or not. When we added the new
`DataSource` in `espresso-validator`, we caused the store to be
created before this flag was inspected, altering the behavior and
causing test failures. This change moves the reset-store before the
creation of the new store, and exposes a single function for doing
both in the correct order.

This also allows us to remove `--reset-store-state` from some tests,
which I had recently added to work around this.

This whole mechanism should be replaced with a simpler, better
thing that is more closely integrated with QueryData. However, that
will be easier to do once we have gotten rid of the old query service.