### PR TITLE
Remove unnecessary parentheses

### DIFF
--- a/core/src/set_merkle_tree.rs
+++ b/core/src/set_merkle_tree.rs
@@ -290,7 +290,7 @@ impl SetMerkleProof {
                 SetMerkleTerminalNode::EmptySubtree {} => false,
                 SetMerkleTerminalNode::Leaf {
                     elem: leaf_elem, ..
-                } => (leaf_elem == &elem),
+                } => leaf_elem == &elem,
             })
         } else {
             Err(running_hash)


### PR DESCRIPTION
I'm not sure why this suddenly started failing main CI, but this should fix the docs build.