### PR TITLE
Add release-no-lto profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ opt-level = 1
 debug = true
 lto = "thin"
 incremental = true
+
+# To speed up the local build, run `cargo build` or `cargo test` with `--profile=release-no-lto`.
 [profile.release-no-lto]
 inherits = "release"
+# Disable LTO to decrease the linking time.
 lto = "off"


### PR DESCRIPTION
- Adds a `release-no-lto` profile to speed up the local build.
- Closes https://github.com/EspressoSystems/espresso/issues/632.