### PR TITLE
Update to clap 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "bincode",
- "clap 3.2.17",
+ "clap 4.0.10",
  "config",
  "dirs",
  "espresso-systems-common 0.2.0 (git+ssh://git@github.com/EspressoSystems/espresso-systems-common.git?tag=0.2.0)",
@@ -38,7 +38,7 @@ dependencies = [
  "strum 0.20.0",
  "strum_macros 0.20.1",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.1)",
  "tempdir",
  "tide",
  "tide-disco",
@@ -1214,33 +1214,31 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "3b1a0a4208c6c483b952ad35c6eed505fc13b46f08f631b81e828084a9318d74"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1251,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -2246,7 +2244,7 @@ name = "espresso-availability-api"
 version = "0.1.0"
 dependencies = [
  "ark-serialize",
- "clap 3.2.17",
+ "clap 4.0.10",
  "commit",
  "derive_more",
  "espresso-core",
@@ -2265,7 +2263,7 @@ name = "espresso-catchup-api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "clap 3.2.17",
+ "clap 4.0.10",
  "derive_more",
  "espresso-core",
  "futures",
@@ -2286,6 +2284,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
+ "clap 4.0.10",
  "derive_more",
  "escargot",
  "espresso-availability-api",
@@ -2317,9 +2316,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "snafu",
- "structopt",
  "surf-disco",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.1)",
  "tempdir",
  "toml",
  "tracing",
@@ -2387,7 +2385,7 @@ dependencies = [
  "strum 0.20.0",
  "strum_macros 0.20.1",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.1)",
  "tempdir",
  "tide",
  "tracing",
@@ -2404,7 +2402,7 @@ dependencies = [
  "async-trait",
  "async_executors",
  "atomic_store 0.1.3 (git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.3)",
- "clap 3.2.17",
+ "clap 4.0.10",
  "commit",
  "derive_more",
  "espresso-availability-api",
@@ -2451,7 +2449,7 @@ dependencies = [
 name = "espresso-metastate-api"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.17",
+ "clap 4.0.10",
  "derive_more",
  "espresso-core",
  "futures",
@@ -2466,7 +2464,7 @@ dependencies = [
 name = "espresso-status-api"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.17",
+ "clap 4.0.10",
  "derive_more",
  "espresso-core",
  "futures",
@@ -2498,7 +2496,7 @@ dependencies = [
  "async-std",
  "async-tungstenite 0.15.0",
  "bincode",
- "clap 3.2.17",
+ "clap 4.0.10",
  "cld",
  "commit",
  "derive_more",
@@ -2541,7 +2539,7 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.20.1",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.1)",
  "tempdir",
  "tide",
  "tide-disco",
@@ -2557,7 +2555,7 @@ name = "espresso-validator-api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "clap 3.2.17",
+ "clap 4.0.10",
  "derive_more",
  "espresso-core",
  "futures",
@@ -2668,6 +2666,7 @@ dependencies = [
  "async-std",
  "atomic_store 0.1.3 (git+https://github.com/EspressoSystems/atomicstore.git)",
  "bincode",
+ "clap 4.0.10",
  "dirs",
  "escargot",
  "espresso-client",
@@ -2688,7 +2687,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "structopt",
  "surf",
  "tempdir",
  "tide",
@@ -3247,7 +3245,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "snafu",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0)",
  "tracing",
 ]
 
@@ -3709,7 +3707,7 @@ dependencies = [
  "serde",
  "sha2 0.10.2",
  "snafu",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0)",
 ]
 
 [[package]]
@@ -3727,7 +3725,7 @@ dependencies = [
  "serde",
  "sha2 0.10.2",
  "snafu",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0)",
 ]
 
 [[package]]
@@ -4738,7 +4736,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0)",
  "tide",
  "tracing",
 ]
@@ -5509,9 +5507,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -6299,7 +6297,7 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.0)",
  "tempdir",
  "tracing",
  "zeroize",
@@ -6947,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "surf-disco"
 version = "0.1.0"
-source = "git+ssh://git@github.com/EspressoSystems/surf-disco.git?branch=main#c60bedec6fafb6b4a7f755c261a4f9f95a707f5c"
+source = "git+ssh://git@github.com/EspressoSystems/surf-disco.git?branch=main#b367bb20a8706bbc83295555744a8c1af848ad9d"
 dependencies = [
  "async-std",
  "async-tungstenite 0.15.0",
@@ -7030,6 +7028,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagged-base64"
+version = "0.2.0"
+source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.1#4ba55dd2f9aaa63601db03a621ea2a1b50d18292"
+dependencies = [
+ "base64 0.13.0",
+ "clap 4.0.10",
+ "console_error_panic_hook",
+ "crc-any",
+ "futures-channel",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7076,12 +7090,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -7147,13 +7155,13 @@ dependencies = [
 [[package]]
 name = "tide-disco"
 version = "0.1.0"
-source = "git+ssh://git@github.com/EspressoSystems/tide-disco.git?branch=main#482f59a9314765ecd8928a7b051b3a9555190bbc"
+source = "git+ssh://git@github.com/EspressoSystems/tide-disco.git?tag=v0.3.0#966c07f862b8f1ff656da5272d2ce668eecbe03c"
 dependencies = [
  "ark-serialize",
  "async-std",
  "async-trait",
  "bincode",
- "clap 3.2.17",
+ "clap 4.0.10",
  "config",
  "derive_more",
  "dirs",
@@ -7180,7 +7188,7 @@ dependencies = [
  "strum 0.20.0",
  "strum_macros 0.20.1",
  "surf",
- "tagged-base64",
+ "tagged-base64 0.2.0 (git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.1)",
  "tide",
  "tide-websockets",
  "toml",

--- a/address-book/Cargo.toml
+++ b/address-book/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 #portpicker = "0.1"
 async-std = { version = "1.8.0", features = ["attributes"] }
 bincode = "1.3.3"
-clap = { version = "3.2.5", features = ["derive"] }
+clap = { version = "4.0", features = ["derive"] }
 config = "0.13.1"
 dirs = "4.0.0"
 espresso-systems-common = { git = "ssh://git@github.com/EspressoSystems/espresso-systems-common.git", tag = "0.2.0" }
@@ -47,10 +47,10 @@ snafu = { version = "0.7", features = ["backtraces"] }
 strum = "0.20"
 strum_macros = "0.20.1"
 surf = "2.3.2"
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.0" }
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.1" }
 tempdir = "0.3.7"
 tide = { version = "0.16.0", default-features = false }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 tide-websockets = "0.4.0"
 toml = "0.5"
 tracing = "0.1.35"

--- a/address-book/src/lib.rs
+++ b/address-book/src/lib.rs
@@ -53,11 +53,11 @@ pub type Result<T> = std::result::Result<T, AddressBookError>;
 
 /// Command line arguments
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 pub struct Args {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub disco_args: DiscoArgs,
-    #[clap(long)]
+    #[arg(long)]
     /// Storage path
     pub store_path: Option<PathBuf>,
 }

--- a/apis/availability/Cargo.toml
+++ b/apis/availability/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [dependencies]
 ark-serialize = { version = "0.3.0", features = ["derive"] }
-clap = { version = "3.2.17", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 derive_more = "0.99"
 espresso-core = { path = "../../core/" }
@@ -27,6 +27,6 @@ hotshot-types = { git = "ssh://git@github.com/EspressoSystems/HotShot.git", tag 
 jf-cap = { features = ["std"], git = "https://github.com/EspressoSystems/cap.git", branch = "testnet-v1" }
 serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 toml = "0.5"
 tracing = "0.1.35"

--- a/apis/availability/src/api.rs
+++ b/apis/availability/src/api.rs
@@ -31,7 +31,7 @@ use tide_disco::{
 
 #[derive(Args, Default)]
 pub struct Options {
-    #[clap(long = "availability-api-path", env = "ESPRESSO_AVAILABILITY_API_PATH")]
+    #[arg(long = "availability-api-path", env = "ESPRESSO_AVAILABILITY_API_PATH")]
     pub api_path: Option<PathBuf>,
 }
 

--- a/apis/catchup/Cargo.toml
+++ b/apis/catchup/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.56"
-clap = { version = "3.2.17", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 derive_more = "0.99"
 espresso-core = { path = "../../core/" }
 futures = "0.3.21"
@@ -26,6 +26,6 @@ postage = { version = "0.5", features = ["futures-traits"] }
 seahorse = { git = "https://github.com/EspressoSystems/seahorse.git" }
 serde = { version = "1.0.139", features = ["derive", "rc"] }
 snafu = { version = "0.7", features = ["backtraces"] }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 toml = "0.5"
 tracing = "0.1.35"

--- a/apis/catchup/src/api.rs
+++ b/apis/catchup/src/api.rs
@@ -25,7 +25,7 @@ use tide_disco::{
 
 #[derive(Args, Default)]
 pub struct Options {
-    #[clap(long = "catchup-api-path", env = "ESPRESSO_CATCHUP_API_PATH")]
+    #[arg(long = "catchup-api-path", env = "ESPRESSO_CATCHUP_API_PATH")]
     pub api_path: Option<PathBuf>,
 }
 

--- a/apis/esqs/Cargo.toml
+++ b/apis/esqs/Cargo.toml
@@ -22,7 +22,7 @@ async-std = { version = "1.10.0", features = ["unstable", "attributes"] }
 async-trait = "0.1.56"
 async_executors = { version = "0.4.2", features = ["async_std"] }
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.3" }
-clap = { version = "3.2.17", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 derive_more = "0.99"
 espresso-availability-api = { path = "../availability" }
@@ -41,5 +41,5 @@ reef = { git = "https://github.com/EspressoSystems/reef.git", features = ["testi
 seahorse = { git = "https://github.com/EspressoSystems/seahorse.git" }
 serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 tracing = "0.1.35"

--- a/apis/esqs/src/full_node.rs
+++ b/apis/esqs/src/full_node.rs
@@ -43,22 +43,22 @@ use tide_disco::{http::Url, App};
 
 #[derive(Args)]
 pub struct Options {
-    #[clap(short, long, env = "ESPRESSO_ESQS_PORT")]
+    #[arg(short, long, env = "ESPRESSO_ESQS_PORT")]
     pub port: u16,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub availability: availability::Options,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub catchup: catchup::Options,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub metastate: metastate::Options,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub status: status::Options,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub validator: validator::Options,
 }
 

--- a/apis/metastate/Cargo.toml
+++ b/apis/metastate/Cargo.toml
@@ -17,12 +17,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.17", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 derive_more = "0.99"
 espresso-core = { path = "../../core/" }
 futures = "0.3.21"
 jf-cap = { features = ["std"], git = "https://github.com/EspressoSystems/cap.git", branch = "testnet-v1" }
 serde = { version = "1.0.139", features = ["derive", "rc"] }
 snafu = { version = "0.7", features = ["backtraces"] }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 toml = "0.5"

--- a/apis/metastate/src/api.rs
+++ b/apis/metastate/src/api.rs
@@ -26,7 +26,7 @@ use tide_disco::{
 
 #[derive(Args, Default)]
 pub struct Options {
-    #[clap(long = "metastate-api-path", env = "ESPRESSO_METASTATE_API_PATH")]
+    #[arg(long = "metastate-api-path", env = "ESPRESSO_METASTATE_API_PATH")]
     pub api_path: Option<PathBuf>,
 }
 

--- a/apis/status/Cargo.toml
+++ b/apis/status/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.17", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 derive_more = "0.99"
 espresso-core = { path = "../../core/" }
 futures = "0.3.21"
@@ -25,5 +25,5 @@ hotshot = { git = "ssh://git@github.com/EspressoSystems/HotShot.git", tag = "0.1
 jf-cap = { features = ["std"], git = "https://github.com/EspressoSystems/cap.git", branch = "testnet-v1" }
 serde = { version = "1.0.139", features = ["derive", "rc"] }
 snafu = { version = "0.7", features = ["backtraces"] }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 toml = "0.5"

--- a/apis/status/src/api.rs
+++ b/apis/status/src/api.rs
@@ -25,7 +25,7 @@ use tide_disco::{
 
 #[derive(Args, Default)]
 pub struct Options {
-    #[clap(long = "status-api-path", env = "ESPRESSO_STATUS_API_PATH")]
+    #[arg(long = "status-api-path", env = "ESPRESSO_STATUS_API_PATH")]
     pub api_path: Option<PathBuf>,
 }
 

--- a/apis/validator/Cargo.toml
+++ b/apis/validator/Cargo.toml
@@ -18,12 +18,12 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.51"
-clap = { version = "3.2.17", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 derive_more = "0.99"
 espresso-core = { path = "../../core/" }
 futures = "0.3.21"
 hotshot = { git = "ssh://git@github.com/EspressoSystems/HotShot.git", tag = "0.1.3" }
 serde = { version = "1.0.139", features = ["derive", "rc"] }
 snafu = { version = "0.7", features = ["backtraces"] }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 toml = "0.5"

--- a/apis/validator/src/api.rs
+++ b/apis/validator/src/api.rs
@@ -25,7 +25,7 @@ use tide_disco::{
 
 #[derive(Args, Default)]
 pub struct Options {
-    #[clap(long = "validator-api-path", env = "ESPRESSO_VALIDATOR_API_PATH")]
+    #[arg(long = "validator-api-path", env = "ESPRESSO_VALIDATOR_API_PATH")]
     pub api_path: Option<PathBuf>,
 }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -31,6 +31,7 @@ address-book = { path = "../address-book" }
 async-std = { version = "1.10.0", features = ["unstable", "attributes"] }
 async-trait = "0.1.56"
 bincode = "1.3.3"
+clap = { version = "4.0", features = ["derive"] }
 derive_more = "0.99"
 escargot = "0.5.2"
 espresso-availability-api = { path = "../apis/availability" }
@@ -49,7 +50,7 @@ jf-primitives = { features = ["std"], git = "https://github.com/EspressoSystems/
 jf-utils = { features = ["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
 key-set = { git = "https://github.com/EspressoSystems/key-set.git" }
 lazy_static = "1.4.0"
-parse-size = "1.0"
+parse-size = { version = "1.0", features = ["std"] }
 portpicker = "0.1"
 primitive-types = "0.11"
 rand = "0.8.5"
@@ -62,9 +63,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0.61"
 snafu = { version = "0.7", features = ["backtraces"] }
-structopt = { version = "0.3", features = ["paw"] }
 surf-disco = { git = "ssh://git@github.com/EspressoSystems/surf-disco.git", branch = "main" }
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.0" }
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.1" }
 tempdir = "0.3.7"
 toml = "0.5"
 tracing = "0.1.35"

--- a/client/src/bin/random-wallet.rs
+++ b/client/src/bin/random-wallet.rs
@@ -33,6 +33,7 @@
 
 use address_book::error::AddressBookError;
 use async_std::task::sleep;
+use clap::Parser;
 use derive_more::Deref;
 use espresso_client::{ledger_state::TransactionUID, network::NetworkBackend, RecordAmount};
 use espresso_core::{ledger::EspressoLedger, universal_params::UNIVERSAL_PARAM};
@@ -60,7 +61,6 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
-use structopt::StructOpt;
 use surf_disco::{Error, StatusCode, Url};
 use tempdir::TempDir;
 use tracing::{event, Level};
@@ -133,44 +133,44 @@ impl Display for Bytes {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct Args {
     /// Path to a private key file to use for the keystore.
     ///
     /// If not given, new keys are generated randomly.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     key_path: Option<PathBuf>,
 
     /// Seed for random number generation.
-    #[structopt(long)]
+    #[arg(long)]
     seed: Option<u64>,
 
     /// Path to a saved keystore, or a new directory where this keystore will be saved.
     /// Will use a TempDir if not provided
-    #[structopt(long, env = "ESPRESSO_RANDOM_WALLET_PATH")]
+    #[arg(long, env = "ESPRESSO_RANDOM_WALLET_PATH")]
     storage: Option<PathBuf>,
 
     /// URL of a server for querying with the ledger
-    #[structopt(short, long, env = "ESPRESSO_ESQS_URL")]
+    #[arg(short, long, env = "ESPRESSO_ESQS_URL")]
     esqs_url: Url,
 
     /// URL of a server for interacting with the ledger
-    #[structopt(short, long, env = "ESPRESSO_SUBMIT_URL")]
+    #[arg(short, long, env = "ESPRESSO_SUBMIT_URL")]
     validator_url: Url,
 
     /// URL of a server for address book
-    #[structopt(short, long, env = "ESPRESSO_ADDRESS_BOOK_URL")]
+    #[arg(short, long, env = "ESPRESSO_ADDRESS_BOOK_URL")]
     address_book_url: Url,
 
-    #[structopt(short, long, env = "ESPRESSO_FAUCET_URL")]
+    #[arg(short, long, env = "ESPRESSO_FAUCET_URL")]
     faucet_url: Url,
 
     /// Whether to color log output with ANSI color codes.
-    #[structopt(long, env = "ESPRESSO_COLORED_LOGS")]
+    #[arg(long, env = "ESPRESSO_COLORED_LOGS")]
     colored_logs: bool,
 
     /// Size of additional padding to add to transfers.
-    #[structopt(long, env = "ESPRESSO_RANDOM_WALLET_PADDING", default_value = "0")]
+    #[arg(long, env = "ESPRESSO_RANDOM_WALLET_PADDING", default_value = "0")]
     padding: Bytes,
 }
 
@@ -248,7 +248,7 @@ async fn get_native_from_faucet(keystore: &mut Keystore, pub_key: &UserPubKey, u
 
 #[async_std::main]
 async fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
 
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -20,6 +20,7 @@
 mod cli_client;
 
 use async_trait::async_trait;
+use clap::Parser;
 use espresso_client::network::NetworkBackend;
 use espresso_core::ledger::EspressoLedger;
 use jf_cap::proof::UniversalParam;
@@ -32,33 +33,30 @@ use seahorse::{
 };
 use std::path::PathBuf;
 use std::process::exit;
-use structopt::StructOpt;
 use surf_disco::Url;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Args {
     /// Generate keys for a keystore, do not run the REPL.
     ///
     /// The keys are stored in FILE and FILE.pub.
-    #[structopt(short = "g", long)]
+    #[arg(short = 'g', long)]
     pub key_gen: Option<PathBuf>,
 
     /// Path to a saved keystore, or a new directory where this keystore will be saved.
     ///
     /// If not given, the keystore will be stored in ~/.translucence/keystore. If a keystore already
     /// exists there, it will be loaded. Otherwise, a new keystore will be created.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub storage: Option<PathBuf>,
 
     /// Create a new keystore and store it an a temporary location which will be deleted on exit.
     ///
     /// This option is mutually exclusive with --storage.
-    #[structopt(long)]
-    #[structopt(conflicts_with("storage"))]
-    #[structopt(hidden(true))]
+    #[arg(long, conflicts_with("storage"), hide(true))]
     pub tmp_storage: bool,
 
-    #[structopt(long)]
+    #[arg(long)]
     /// Run in a mode which is friendlier to automated scripting.
     ///
     /// Instead of prompting the user for input with a line editor, the prompt will be printed,
@@ -66,7 +64,7 @@ pub struct Args {
     pub non_interactive: bool,
 
     /// URL for the Espresso Query Service.
-    #[structopt(
+    #[arg(
         long,
         env = "ESPRESSO_ESQS_URL",
         default_value = "http://localhost:50087"
@@ -74,7 +72,7 @@ pub struct Args {
     pub esqs_url: Url,
 
     /// URL for the Espresso address book.
-    #[structopt(
+    #[arg(
         long,
         env = "ESPRESSO_ADDRESS_BOOK_URL",
         default_value = "http://localhost:50088"
@@ -82,7 +80,7 @@ pub struct Args {
     pub address_book_url: Url,
 
     /// URL for a validator to submit transactions to.
-    #[structopt(
+    #[arg(
         long,
         env = "ESPRESSO_SUBMIT_URL",
         default_value = "http://localhost:50089"
@@ -145,7 +143,7 @@ impl<'a> CLI<'a> for EspressoCli {
 
 #[async_std::main]
 async fn main() {
-    if let Err(err) = cli_main::<EspressoLedger, EspressoCli>(Args::from_args()).await {
+    if let Err(err) = cli_main::<EspressoLedger, EspressoCli>(Args::parse()).await {
         println!("{}", err);
         exit(1);
     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -73,7 +73,7 @@ snafu = { version = "0.7", features = ["backtraces"] }
 strum = "0.20"
 strum_macros = "0.20.1"
 surf = "2.3.1"
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.0" }
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.1" }
 tempdir = "0.3.7"
 tide = "0.16.0"
 tracing = "0.1.35"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -42,6 +42,7 @@ async-std = "1.10.0"
 
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", version = "0.1.3" }
 bincode = "1.3.3"
+clap = { version = "4.0", features = ["derive"] }
 dirs = "4.0.0"
 espresso-client = { path = "../client" }
 espresso-core = { path = "../core/" }
@@ -59,7 +60,6 @@ reef = { git = "https://github.com/EspressoSystems/reef.git" }
 serde = "1.0.139"
 serde_json = "1.0.67"
 snafu = "0.7.1"
-structopt = "0.3.26"
 surf = "2.3.2"
 tempdir = "0.3.7"
 tide = "0.16.0"

--- a/faucet/src/bin/faucet-shower.rs
+++ b/faucet/src/bin/faucet-shower.rs
@@ -15,6 +15,7 @@
 //! Give faucet-shower a master mnemonic for a funded keystore and a number N and it will generate N
 //! new keystores, transfer some tokens from the master keystore to each new keystore, and print the
 //! mnemonics and public keys of the newly funded keystores.
+use clap::Parser;
 use espresso_client::{
     hd::{KeyTree, Mnemonic},
     ledger_state::TransactionStatus,
@@ -33,30 +34,29 @@ use rand_chacha::{
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::time::Duration;
-use structopt::StructOpt;
 use surf::Url;
 use tempdir::TempDir;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Options {
     /// mnemonic for the master faucet keystore
-    #[structopt(short, long, env = "ESPRESSO_FAUCET_WALLET_MNEMONIC")]
+    #[arg(short, long, env = "ESPRESSO_FAUCET_WALLET_MNEMONIC")]
     pub master_mnemonic: Mnemonic,
 
     /// number of new keystores to generate
-    #[structopt(short, long, default_value = "10")]
+    #[arg(short, long, default_value = "10")]
     pub num_keystores: usize,
 
     /// number of records to create in each new keystore
-    #[structopt(short, long, default_value = "1")]
+    #[arg(short, long, default_value = "1")]
     pub num_records: u64,
 
     /// size of each record to create in the new keystores
-    #[structopt(short, long, default_value = "1000000")]
+    #[arg(short, long, default_value = "1000000")]
     pub record_size: u64,
 
     /// URL for the Ethereum Query Service.
-    #[structopt(
+    #[arg(
         long,
         env = "ESPRESSO_ESQS_URL",
         default_value = "http://localhost:50087"
@@ -90,7 +90,7 @@ async fn create_keystore(
 
 #[async_std::main]
 async fn main() {
-    let opt = Options::from_args();
+    let opt = Options::parse();
     let mut rng = ChaChaRng::from_entropy();
     let dir = TempDir::new("faucet-shower").unwrap();
 

--- a/faucet/src/faucet_keystore_test_setup.rs
+++ b/faucet/src/faucet_keystore_test_setup.rs
@@ -12,10 +12,10 @@
 
 //! A script to export environment variables for test deployments of the Esresso testnet.
 
+use clap::Parser;
 use espresso_client::hd::{KeyTree, Mnemonic};
 use num_bigint::BigUint;
 use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
-use structopt::StructOpt;
 
 pub fn field_to_hex(f: impl Into<BigUint>) -> String {
     let bytes = f
@@ -27,20 +27,20 @@ pub fn field_to_hex(f: impl Into<BigUint>) -> String {
     hex::encode(&bytes)
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[command(
     name = "Espresso Faucet utility",
     about = "Create address and encryption key from mnemonic"
 )]
 pub struct Options {
     /// mnemonic for the faucet keystore (if not provided, a random mnemonic will be generated)
-    #[structopt(long, env = "ESPRESSO_FAUCET_MANAGER_MNEMONIC")]
+    #[arg(long, env = "ESPRESSO_FAUCET_MANAGER_MNEMONIC")]
     pub mnemonic: Option<String>,
 }
 
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
-    let opt = Options::from_args();
+    let opt = Options::parse();
     let mnemonic = match opt.mnemonic {
         Some(phrase) => Mnemonic::from_phrase(phrase.replace('-', " ")).unwrap(),
         None => KeyTree::random(&mut ChaChaRng::from_entropy()).1,

--- a/faucet/types/Cargo.toml
+++ b/faucet/types/Cargo.toml
@@ -24,4 +24,4 @@ net = { git = "https://github.com/EspressoSystems/net.git" }
 serde = "1.0.139"
 snafu = "0.7.1"
 tide = "0.16.0"
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -25,7 +25,7 @@ ark-std = { version = "0.3.0", default-features = false }
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 async-tungstenite = { version = "0.15.0", features = ["async-std-runtime"], optional = true }
 bincode = "1.3.3"
-clap = { version = "3.2.17", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 cld = "0.4"
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 derive_more = "0.99"
@@ -66,10 +66,10 @@ snafu = { version = "0.7", features = ["backtraces"] }
 strum = "0.24"
 strum_macros = "0.20.1"
 surf = "2.3.1"
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.0" }
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64.git", tag = "0.2.1" }
 tempdir = "0.3.7"
 tide = { version = "0.16.0", default-features = false }
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main", optional = true }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0", optional = true }
 tracing = "0.1.35"
 tracing-distributed = "0.3.1"
 tracing-futures = "0.2"
@@ -92,7 +92,7 @@ testing = [ "address-book"
 address-book = { path = "../address-book" }
 espresso-client = { path = "../client" }
 portpicker = "0.1"
-tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", branch = "main" }
+tide-disco = { git = "ssh://git@github.com/EspressoSystems/tide-disco.git", tag = "v0.3.0" }
 tracing-test = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/validator/src/bin/espresso-validator.rs
+++ b/validator/src/bin/espresso-validator.rs
@@ -30,27 +30,26 @@ use tagged_base64::TaggedBase64;
 use tracing::info;
 
 #[derive(Parser)]
-#[clap(
+#[command(
     name = "Multi-machine consensus",
     about = "Simulates consensus among multiple machines"
 )]
 struct Options {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opt: NodeOpt,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     consensus_opt: ConsensusOpt,
 
     /// Id of the current node.
     ///
     /// If the node ID is 0, it will propose and try to add transactions.
-    #[clap(long, short, env = "ESPRESSO_VALIDATOR_ID")]
-    #[clap(requires("num-nodes"))]
+    #[arg(long, short, env = "ESPRESSO_VALIDATOR_ID", requires("num-nodes"))]
     pub id: usize,
 
     /// Number of nodes, including a fixed number of bootstrap nodes and a dynamic number of non-
     /// bootstrap nodes.
-    #[clap(long, short, env = "ESPRESSO_VALIDATOR_NUM_NODES")]
+    #[arg(long, short, env = "ESPRESSO_VALIDATOR_NUM_NODES")]
     pub num_nodes: usize,
 
     /// Public key which should own a faucet record in the genesis block.
@@ -60,24 +59,24 @@ struct Options {
     ///
     /// This option may be passed multiple times to initialize the ledger with multiple native
     /// token records.
-    #[clap(long, env = "ESPRESSO_FAUCET_PUB_KEYS", value_delimiter = ',')]
+    #[arg(long, env = "ESPRESSO_FAUCET_PUB_KEYS", value_delimiter = ',')]
     pub faucet_pub_key: Vec<UserPubKey>,
 
     /// Number of transactions to generate.
     ///
     /// If not provided, the validator will wait for externally submitted transactions.
-    #[clap(long, short, conflicts_with("faucet-pub-key"))]
+    #[arg(long, short, conflicts_with("faucet-pub-key"))]
     pub num_txn: Option<u64>,
 
     /// Whether to color log output with ANSI color codes.
-    #[clap(long, env = "ESPRESSO_COLORED_LOGS")]
+    #[arg(long, env = "ESPRESSO_COLORED_LOGS")]
     pub colored_logs: bool,
 
     /// Unique identifier for this instance of Espresso.
-    #[clap(long, env = "ESPRESSO_VALIDATOR_CHAIN_ID", default_value = "0")]
+    #[arg(long, env = "ESPRESSO_VALIDATOR_CHAIN_ID", default_value = "0")]
     pub chain_id: u16,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub esqs: Option<full_node::Command>,
 }
 
@@ -250,7 +249,7 @@ async fn generate_transactions(
 
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
-    let options = Options::from_args();
+    let options = Options::parse();
     if let Err(msg) = options.node_opt.check() {
         eprintln!("{}", msg);
         exit(1);

--- a/validator/src/bin/measure-throughput.rs
+++ b/validator/src/bin/measure-throughput.rs
@@ -25,17 +25,17 @@ use tracing::{error, info};
 #[derive(Parser)]
 struct Options {
     /// The frequency at which to poll current throughput.
-    #[clap(short, long, default_value = "60s", parse(try_from_str = espresso_validator::parse_duration))]
+    #[arg(short, long, default_value = "60s", value_parser = espresso_validator::parse_duration)]
     frequency: Duration,
 
     /// The total duration over which to measure throughput.
     ///
     /// If not provided, runs until killed.
-    #[clap(short, long, parse(try_from_str = espresso_validator::parse_duration))]
+    #[arg(short, long, value_parser = espresso_validator::parse_duration)]
     total: Option<Duration>,
 
     /// The query service to poll for ledger state.
-    #[clap(short = 'q', long, env = "ESPRESSO_ESQS_URL")]
+    #[arg(short = 'q', long, env = "ESPRESSO_ESQS_URL")]
     esqs_url: Url,
 }
 
@@ -103,7 +103,7 @@ async fn main() -> surf::Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let opt = Options::from_args();
+    let opt = Options::parse();
     let frequency = opt.frequency;
     let total = opt.total.map(Duration::from);
 

--- a/validator/src/bin/multi_machine_automation.rs
+++ b/validator/src/bin/multi_machine_automation.rs
@@ -22,17 +22,17 @@ use std::process::{exit, Command, Stdio};
 use std::time::Duration;
 
 #[derive(Parser)]
-#[clap(
+#[command(
     name = "Multi-machine consensus",
     about = "Simulates consensus among multiple machines"
 )]
 struct Options {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opt: NodeOpt,
 
     /// Number of nodes, including a fixed number of bootstrap nodes and a dynamic number of
     /// non-bootstrap nodes.
-    #[clap(long, short, env = "ESPRESSO_VALIDATOR_NUM_NODES")]
+    #[arg(long, short, env = "ESPRESSO_VALIDATOR_NUM_NODES")]
     pub num_nodes: usize,
 
     /// Public key which should own a faucet record in the genesis block.
@@ -42,37 +42,37 @@ struct Options {
     ///
     /// This option may be passed multiple times to initialize the ledger with multiple native
     /// token records.
-    #[clap(long, env = "ESPRESSO_FAUCET_PUB_KEYS", value_delimiter = ',')]
+    #[arg(long, env = "ESPRESSO_FAUCET_PUB_KEYS", value_delimiter = ',')]
     pub faucet_pub_key: Vec<UserPubKey>,
 
     /// Number of transactions to generate.
     ///
     /// If not provided, the validator will wait for externally submitted transactions.
-    #[clap(long, short, conflicts_with("faucet-pub-key"))]
+    #[arg(long, short, conflicts_with("faucet-pub-key"))]
     pub num_txn: Option<u64>,
 
     /// Wait for web server to exit after transactions complete.
-    #[clap(long, short)]
+    #[arg(long, short)]
     pub wait: bool,
 
     /// Options for the new EsQS.
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub esqs: Option<full_node::Command>,
 
-    #[clap(long, short)]
+    #[arg(long, short)]
     verbose: bool,
 
     /// Number of nodes to run only `fail_after_txn` rounds.
     ///
     /// If not provided, all nodes will keep running till `num_txn` rounds are completed.
-    #[clap(long)]
+    #[arg(long)]
     num_fail_nodes: Option<usize>,
 
     /// Number of rounds that all nodes will be running, after which `num_fail_nodes` nodes will be
     /// killed.
     ///
     /// If not provided, all nodes will keep running till `num_txn` rounds are completed.
-    #[clap(long, requires("num-fail-nodes"))]
+    #[arg(long, requires("num-fail-nodes"))]
     fail_after_txn: Option<usize>,
 }
 
@@ -89,13 +89,13 @@ fn cargo_run(bin: impl AsRef<str>) -> Command {
 #[async_std::main]
 async fn main() {
     // Construct arguments to pass to the multi-machine demo.
-    let options = Options::from_args();
+    let options = Options::parse();
     if let Err(msg) = options.node_opt.check() {
         eprintln!("{}", msg);
         exit(1);
     }
 
-    // With StructOpt/CLAP, environment variables override command line arguments, but we are going
+    // With clap, environment variables override command line arguments, but we are going
     // to construct a command line for each child, so the child processes shouldn't get their
     // options from the environment. Clear the environment variables corresponding to each option
     // that we will set explicitly in the command line.

--- a/validator/src/bin/test-query-api.rs
+++ b/validator/src/bin/test-query-api.rs
@@ -52,11 +52,11 @@ use tracing::{event, Level};
 #[derive(Parser)]
 struct Args {
     /// Hostname or IP address of the query server.
-    #[clap(short = 'H', long = "--host", default_value = "localhost")]
+    #[arg(short = 'H', long = "--host", default_value = "localhost")]
     host: String,
 
     /// Port number of the query service.
-    #[clap(short = 'P', long = "--port", default_value = "50000")]
+    #[arg(short = 'P', long = "--port", default_value = "50000")]
     port: u16,
 }
 
@@ -261,7 +261,7 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
-    test(&Args::from_args()).await
+    test(&Args::parse()).await
 }
 
 #[cfg(all(test, feature = "slow-tests"))]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -156,13 +156,13 @@ pub struct NodeOpt {
     ///
     /// If the path to a node's persistence files doesn't exist, its persisted state will be reset
     /// regardless of this argument.
-    #[clap(long, short)]
+    #[arg(long, short)]
     pub reset_store_state: bool,
 
     /// Path to persistence files for all nodes.
     ///
     /// Persistence files will be nested under the specified directory.
-    #[clap(long, short, env = "ESPRESSO_VALIDATOR_STORE_PATH")]
+    #[arg(long, short, env = "ESPRESSO_VALIDATOR_STORE_PATH")]
     pub store_path: Option<PathBuf>,
 
     /// Port of the current node if it's non-bootstrap.
@@ -171,7 +171,7 @@ pub struct NodeOpt {
     ///
     /// If the node is bootstrap, thip option will be overriden by the corresponding port in
     /// `--bootstrap-nodes`.
-    #[clap(long, env = "ESPRESSO_VALIDATOR_NONBOOTSTRAP_PORT")]
+    #[arg(long, env = "ESPRESSO_VALIDATOR_NONBOOTSTRAP_PORT")]
     pub nonbootstrap_port: Option<u16>,
 
     /// The base port for the non-bootstrap nodes.
@@ -179,7 +179,7 @@ pub struct NodeOpt {
     /// If specified, the consesnsu port for node `i` will be `nonbootstrap_base_port + i`.
     ///
     /// Will be overriden by `nonbootstrap_port`.
-    #[clap(long, default_value = "9000")]
+    #[arg(long, default_value = "9000")]
     pub nonbootstrap_base_port: usize,
 
     /// Minimum time to wait for submitted transactions before proposing a block.
@@ -187,11 +187,11 @@ pub struct NodeOpt {
     /// Increasing this trades off latency for throughput: the rate of new block proposals gets
     /// slower, but each block is proportionally larger. Because of batch verification, larger
     /// blocks should lead to increased throughput.
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_MIN_PROPOSE_TIME",
         default_value = "0s",
-        parse(try_from_str = parse_duration)
+        value_parser = parse_duration
     )]
     pub min_propose_time: Duration,
 
@@ -199,25 +199,25 @@ pub struct NodeOpt {
     ///
     /// If a validator has not received any transactions after `min-propose-time`, it will wait up
     /// to `max-propose-time` before giving up and submitting an empty block.
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_MAX_PROPOSE_TIME",
         default_value = "10s",
-        parse(try_from_str = parse_duration)
+        value_parser = parse_duration
     )]
     pub max_propose_time: Duration,
 
     /// Base duration for next-view timeout.
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_NEXT_VIEW_TIMEOUT",
         default_value = "100s",
-        parse(try_from_str = parse_duration)
+        value_parser = parse_duration
     )]
     pub next_view_timeout: Duration,
 
     /// The exponential backoff ratio for the next-view timeout.
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_TIMEOUT_RATIO",
         default_value = "11:10"
@@ -225,21 +225,21 @@ pub struct NodeOpt {
     pub timeout_ratio: Ratio,
 
     /// The delay a leader inserts before starting pre-commit.
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_ROUND_START_DELAY",
         default_value = "1ms",
-        parse(try_from_str = parse_duration)
+        value_parser = parse_duration
     )]
     pub round_start_delay: Duration,
 
     /// Delay after init before starting consensus.
-    #[clap(long, env = "ESPRESSO_VALIDATOR_START_DELAY", default_value = "1ms",
-        parse(try_from_str = parse_duration))]
+    #[arg(long, env = "ESPRESSO_VALIDATOR_START_DELAY", default_value = "1ms",
+        value_parser = parse_duration)]
     pub start_delay: Duration,
 
     /// Maximum number of transactions in a block.
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_MAX_TRANSACTIONS",
         default_value = "10000"
@@ -332,60 +332,60 @@ impl From<SecretKeySeed> for [u8; 32] {
 #[derive(Clone, Debug, Args)]
 pub struct ConsensusOpt {
     /// Seed number used to generate secret key set for all nodes.
-    #[clap(long, env = "ESPRESSO_VALIDATOR_SECRET_KEY_SEED")]
+    #[arg(long, env = "ESPRESSO_VALIDATOR_SECRET_KEY_SEED")]
     pub secret_key_seed: Option<SecretKeySeed>,
 
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_REPLICATION_FACTOR",
         default_value = "5"
     )]
     pub replication_factor: usize,
 
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_BOOTSTRAP_MESH_N_HIGH",
         default_value = "50"
     )]
     pub bootstrap_mesh_n_high: usize,
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_BOOTSTRAP_MESH_N_LOW",
         default_value = "10"
     )]
     pub bootstrap_mesh_n_low: usize,
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_BOOTSTRAP_MESH_OUTBOUND_MIN",
         default_value = "5"
     )]
     pub bootstrap_mesh_outbound_min: usize,
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_BOOTSTRAP_MESH_N",
         default_value = "15"
     )]
     pub bootstrap_mesh_n: usize,
 
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_NONBOOTSTRAP_MESH_N_HIGH",
         default_value = "15"
     )]
     pub nonbootstrap_mesh_n_high: usize,
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_NONBOOTSTRAP_MESH_N_LOW",
         default_value = "8"
     )]
     pub nonbootstrap_mesh_n_low: usize,
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_NONBOOTSTRAP_MESH_OUTBOUND_MIN",
         default_value = "4"
     )]
     pub nonbootstrap_mesh_outbound_min: usize,
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_NONBOOTSTRAP_MESH_N",
         default_value = "12"
@@ -393,7 +393,7 @@ pub struct ConsensusOpt {
     pub nonbootstrap_mesh_n: usize,
 
     /// URLs of the bootstrap nodes, in the format of `<host>:<port>`.
-    #[clap(
+    #[arg(
         long,
         env = "ESPRESSO_VALIDATOR_BOOTSTRAP_NODES",
         default_value = "localhost:9000,localhost:9001,localhost:9002,localhost:9003,localhost:9004,localhost:9005,localhost:9006",


### PR DESCRIPTION
There remain a number of outdated indirect dependencies. Projects that will need to be updated include all of jellyfish, seahorse, net, and, yes, HotShot.