### PR TITLE
Fix slow tests

### DIFF
--- a/client/src/cli_client.rs
+++ b/client/src/cli_client.rs
@@ -671,7 +671,6 @@ fn cargo_run(package: impl AsRef<str>, bin: impl AsRef<str>) -> Result<Command, 
         .package(package.as_ref())
         .bin(bin.as_ref())
         .current_release()
-        .current_target()
         .run()
         .map_err(err)?
         .command())

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -997,7 +997,6 @@ mod test {
             self.process = Some(
                 CargoBuild::new()
                     .current_release()
-                    .current_target()
                     .bin("faucet")
                     .run()
                     .unwrap()

--- a/validator/src/bin/multi-machine-automation.rs
+++ b/validator/src/bin/multi-machine-automation.rs
@@ -73,7 +73,6 @@ fn cargo_run(bin: impl AsRef<str>) -> Command {
     CargoBuild::new()
         .bin(bin.as_ref())
         .current_release()
-        .current_target()
         .run()
         .expect("Failed to build.")
         .command()

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -344,7 +344,7 @@ pub fn parse_duration(s: &str) -> Result<Duration, ParseDurationError> {
 }
 
 impl NodeOpt {
-    fn new(num_nodes: usize) -> Self {
+    pub fn new(num_nodes: usize) -> Self {
         Self::parse_from(vec!["--", "--num-nodes", &num_nodes.to_string()])
     }
 }


### PR DESCRIPTION
* Fix unused function warning causing build error in cdn-server
* Remove `.current_target()` from `escargot::CargoBuild` invocations. THIS FUNCTION DOES NOT DO WHAT YOU THINK. It _forces_ the target to be literally the architecture you're running on (e.g. x86_64-apple-darwin). So if the actual profile is just "release", with the target implicitly the same as the host architecture, such escargot invocations will build for a different (equivalent) target, which uses twice as much disk space and takes twice as long to build.