### PR TITLE
`flake.nix`: `pkgconfig`=>`pkg-config`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
         };
         rustDeps = with pkgs;
           [
-            pkgconfig
+            pkg-config
             openssl
             bash
 


### PR DESCRIPTION
Closes #787 

I didn't verify everything e2e, I just checked that the shell build could at least _begin_ to work. 